### PR TITLE
Temporal operator bridge and state quantization

### DIFF
--- a/docs/roadmap-30day.md
+++ b/docs/roadmap-30day.md
@@ -51,19 +51,19 @@ validation
 ## Week 2: Temporal Operator Bridge & State Lowering
 
 ### 2.1 Create Temporal Operator Interface
-- [ ] Define `TemporalOperator` base class (wraps current `Operator`)
-- [ ] Add `temporal_metadata()` method for state threading hints
-- [ ] Implement for built-in ops: Add, MatMul (no state), Delay (stateful)
+- [x] Define `TemporalOperator` base class (wraps current `Operator`)
+- [x] Add `temporal_metadata()` method for state threading hints
+- [x] Implement for built-in ops: Add, MatMul (no state), Delay (stateful)
 - [ ] Pattern detection: identify scan/loop structure in ONNX
 
 **Deliverable**: `src/tempo_dag/ops/temporal_builtins.py` with Delay,
 RollingWindow, ScanCell
 
 ### 2.2 Implement Delay & RollingBuffer Operators
-- [ ] `Delay(value, lag_cycles)`: output is input from N timesteps ago
-- [ ] `RollingWindow(buffer, window_size)`: causal sliding window view
-- [ ] `RollingMean`, `RollingVar`: streaming statistics
-- [ ] Attach fixed-point range metadata to each
+- [x] `Delay(value, lag_cycles)`: output is input from N timesteps ago
+- [x] `RollingWindow(buffer, window_size)`: causal sliding window view
+- [x] `RollingMean`, `RollingVar`: streaming statistics
+- [x] Attach fixed-point range metadata to each
 
 **Deliverable**: Working delay and windowing operators with tests
 

--- a/docs/roadmap-30day.md
+++ b/docs/roadmap-30day.md
@@ -54,7 +54,7 @@ validation
 - [x] Define `TemporalOperator` base class (wraps current `Operator`)
 - [x] Add `temporal_metadata()` method for state threading hints
 - [x] Implement for built-in ops: Add, MatMul (no state), Delay (stateful)
-- [ ] Pattern detection: identify scan/loop structure in ONNX
+- [x] Pattern detection: identify scan/loop structure in ONNX
 
 **Deliverable**: `src/tempo_dag/ops/temporal_builtins.py` with Delay,
 RollingWindow, ScanCell

--- a/docs/roadmap-30day.md
+++ b/docs/roadmap-30day.md
@@ -68,9 +68,9 @@ RollingWindow, ScanCell
 **Deliverable**: Working delay and windowing operators with tests
 
 ### 2.3 Extend Quantization Config for Temporal State
-- [ ] Add `StateQuantSpec` dataclass (dtype, scale, overflow_policy)
-- [ ] Update `NumericalParityConfig` to handle state across timesteps
-- [ ] Create sample fixed-point profiles for rolling statistics
+- [x] Add `StateQuantSpec` dataclass (dtype, scale, overflow_policy)
+- [x] Update `NumericalParityConfig` to handle state across timesteps
+- [x] Create sample fixed-point profiles for rolling statistics
 
 **Deliverable**: Quantization config extends to state values
 

--- a/src/tempo_dag/numerical_parity.py
+++ b/src/tempo_dag/numerical_parity.py
@@ -15,6 +15,7 @@ from tempo_dag.quantization_config import (
     QuantizationScheme,
     QuantizationSpec,
     QuantizationType,
+    StateQuantSpec,
     compute_quant_params,
 )
 
@@ -144,6 +145,7 @@ class NumericalParityConfig:
     fp32_ir: Graph | None = None
     quantized_ir: Graph | None = None
     ranking_metric: str = "max_error"
+    state_quantization: dict[str, StateQuantSpec] = field(default_factory=dict)
 
     @classmethod
     def from_input(
@@ -173,6 +175,9 @@ class NumericalParityConfig:
             fp32_ir=cast("Graph | None", config.get("fp32_ir")),
             quantized_ir=cast("Graph | None", config.get("quantized_ir")),
             ranking_metric=str(config.get("ranking_metric", "max_error")),
+            state_quantization=_coerce_state_quantization(
+                config.get("state_quantization")
+            ),
         )
 
 
@@ -201,6 +206,30 @@ def _coerce_optional_str_sequence(value: object | None) -> tuple[str, ...] | Non
     if isinstance(value, Sequence) and not isinstance(value, str | bytes):
         return tuple(str(item) for item in value)
     raise TypeError("config layer_names must be a sequence of strings")
+
+
+def _coerce_state_quantization(
+    value: object | None,
+) -> dict[str, StateQuantSpec]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError("config state_quantization must be a mapping")
+
+    specs: dict[str, StateQuantSpec] = {}
+    for state_id, raw_spec in value.items():
+        if not isinstance(state_id, str):
+            raise TypeError("state_quantization keys must be strings")
+        if isinstance(raw_spec, StateQuantSpec):
+            specs[state_id] = raw_spec
+        elif isinstance(raw_spec, dict):
+            specs[state_id] = StateQuantSpec.from_dict(raw_spec)
+        else:
+            raise TypeError(
+                "state_quantization values must be StateQuantSpec instances "
+                "or dictionaries"
+            )
+    return specs
 
 
 def _coerce_thresholds(value: object | None) -> dict[str, float]:

--- a/src/tempo_dag/ops/__init__.py
+++ b/src/tempo_dag/ops/__init__.py
@@ -1,5 +1,7 @@
 from .builtins import register_builtin_operators
+from .temporal_builtins import register_temporal_builtin_operators
 
 __all__ = [
     "register_builtin_operators",
+    "register_temporal_builtin_operators",
 ]

--- a/src/tempo_dag/ops/temporal_builtins.py
+++ b/src/tempo_dag/ops/temporal_builtins.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+from tempo_dag.ir.op import FPGACost, InvalidOperatorInstanceError
+from tempo_dag.ir.registry import OperatorRegistry
+from tempo_dag.ir.value import Value, ValueType
+from tempo_dag.ops.builtins import Add, BuiltinOperator, MatMul, _shape_product
+
+
+@dataclass(frozen=True)
+class FixedPointRange:
+    """Fixed-point range hint attached before full quantization is resolved."""
+
+    minimum: float
+    maximum: float
+    signed: bool = True
+
+    def __post_init__(self) -> None:
+        if self.minimum > self.maximum:
+            raise ValueError("minimum must be <= maximum")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "minimum": self.minimum,
+            "maximum": self.maximum,
+            "signed": self.signed,
+        }
+
+
+@dataclass(frozen=True)
+class TemporalMetadata:
+    """State-threading metadata consumed by temporal lowering passes."""
+
+    op_id: str
+    op_type: str
+    stateful: bool
+    state_reads: tuple[str, ...] = ()
+    state_writes: tuple[str, ...] = ()
+    buffers: tuple[str, ...] = ()
+    lag_cycles: int = 0
+    window_size: int | None = None
+    fixed_point_ranges: dict[str, FixedPointRange] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "op_id": self.op_id,
+            "op_type": self.op_type,
+            "stateful": self.stateful,
+            "state_reads": list(self.state_reads),
+            "state_writes": list(self.state_writes),
+            "buffers": list(self.buffers),
+            "lag_cycles": self.lag_cycles,
+            "window_size": self.window_size,
+            "fixed_point_ranges": {
+                value_id: value_range.to_dict()
+                for value_id, value_range in sorted(self.fixed_point_ranges.items())
+            },
+        }
+
+
+class TemporalOperator(BuiltinOperator):
+    """Base class for operators that expose temporal lowering metadata."""
+
+    OP_TYPE: ClassVar[str | None] = "_TemporalOperatorBase"
+
+    def temporal_metadata(self, values: Mapping[str, Value]) -> TemporalMetadata:
+        self.validate(values)
+        return TemporalMetadata(
+            op_id=self.op_id,
+            op_type=self.op_type,
+            stateful=False,
+            fixed_point_ranges=_fixed_point_ranges(self.attrs, self.outputs),
+        )
+
+    def _buffer_id(self, *, default: str) -> str:
+        return _string_attr(self.attrs, "buffer_id", default)
+
+    def _state_id(self, *, default: str) -> str:
+        return _string_attr(self.attrs, "state_id", default)
+
+    def _state_ids(self) -> list[str]:
+        return _string_sequence_attr(self.attrs, "state_ids")
+
+
+class TemporalAdd(Add, TemporalOperator):
+    """Temporal-aware stateless Add bridge."""
+
+
+class TemporalMatMul(MatMul, TemporalOperator):
+    """Temporal-aware stateless MatMul bridge."""
+
+
+class Delay(TemporalOperator):
+    """Causal delay line that returns input from N timesteps ago."""
+
+    OP_TYPE = "Delay"
+
+    def validate(self, values: Mapping[str, Value]) -> None:
+        self._require_input_count(1)
+        self._require_output_count(1)
+        lag_cycles = self._lag_cycles()
+        input_value = self._input_values(values)[0]
+        self._require_scalar_or_tensor(input_value, "input[0]")
+        output_type = (
+            ValueType.SCALAR
+            if input_value.vtype is ValueType.SCALAR
+            else ValueType.TENSOR
+        )
+        self._match_output(
+            values,
+            shape=input_value.shape,
+            axes=input_value.axes,
+            dtype=input_value.dtype,
+            vtype=output_type,
+        )
+        if lag_cycles < 1:
+            raise InvalidOperatorInstanceError("Delay requires lag_cycles >= 1")
+
+    def temporal_metadata(self, values: Mapping[str, Value]) -> TemporalMetadata:
+        self.validate(values)
+        buffer_id = self._buffer_id(default=f"{self.op_id}_buffer")
+        return TemporalMetadata(
+            op_id=self.op_id,
+            op_type=self.op_type,
+            stateful=True,
+            state_reads=(buffer_id,),
+            state_writes=(buffer_id,),
+            buffers=(buffer_id,),
+            lag_cycles=self._lag_cycles(),
+            fixed_point_ranges=_fixed_point_ranges(self.attrs, self.outputs),
+        )
+
+    def estimate_fpga_cost(self, values: Mapping[str, Value]) -> FPGACost:
+        input_value = self._input_values(values)[0]
+        work = max(1, _shape_product(input_value.shape))
+        return FPGACost(
+            latency_cycles=1,
+            initiation_interval=1,
+            bram=max(1, (work * self._lag_cycles() + 255) // 256),
+            lut=max(1, work // 2),
+            ff=max(1, work),
+            metadata={"heuristic": "temporal_delay", "lag_cycles": self._lag_cycles()},
+        )
+
+    def _lag_cycles(self) -> int:
+        return self._optional_int_attr("lag_cycles", 1)
+
+
+class RollingWindow(TemporalOperator):
+    """Causal rolling window view backed by bounded history state."""
+
+    OP_TYPE = "RollingWindow"
+
+    def validate(self, values: Mapping[str, Value]) -> None:
+        self._require_input_count(1)
+        self._require_output_count(1)
+        window_size = self._window_size()
+        input_value = self._input_values(values)[0]
+        self._require_tensor(input_value, "input[0]")
+        self._match_output(
+            values,
+            shape=[window_size, *input_value.shape],
+            axes=["window", *input_value.axes],
+            dtype=input_value.dtype,
+            vtype=ValueType.TENSOR,
+        )
+
+    def temporal_metadata(self, values: Mapping[str, Value]) -> TemporalMetadata:
+        self.validate(values)
+        buffer_id = self._buffer_id(default=f"{self.op_id}_buffer")
+        return TemporalMetadata(
+            op_id=self.op_id,
+            op_type=self.op_type,
+            stateful=True,
+            state_reads=(buffer_id,),
+            state_writes=(buffer_id,),
+            buffers=(buffer_id,),
+            lag_cycles=1,
+            window_size=self._window_size(),
+            fixed_point_ranges=_fixed_point_ranges(self.attrs, self.outputs),
+        )
+
+    def estimate_fpga_cost(self, values: Mapping[str, Value]) -> FPGACost:
+        input_value = self._input_values(values)[0]
+        work = max(1, _shape_product(input_value.shape))
+        window_size = self._window_size()
+        return FPGACost(
+            latency_cycles=window_size,
+            initiation_interval=1,
+            bram=max(1, (work * window_size + 255) // 256),
+            lut=max(1, work),
+            ff=max(1, work),
+            metadata={"heuristic": "rolling_window", "window_size": window_size},
+        )
+
+    def _window_size(self) -> int:
+        window_size = self._optional_int_attr("window_size", 1)
+        if window_size < 1:
+            raise InvalidOperatorInstanceError(
+                f"{self.op_type} requires window_size >= 1"
+            )
+        return window_size
+
+
+class _RollingStat(TemporalOperator):
+    OP_TYPE: ClassVar[str | None] = "_RollingStatBase"
+    STAT_NAME: ClassVar[str] = "stat"
+
+    def validate(self, values: Mapping[str, Value]) -> None:
+        self._require_input_count(1)
+        self._require_output_count(1)
+        window_size = self._window_size()
+        input_value = self._input_values(values)[0]
+        self._require_tensor(input_value, "input[0]")
+        self._match_output(
+            values,
+            shape=input_value.shape,
+            axes=input_value.axes,
+            dtype=input_value.dtype,
+            vtype=ValueType.TENSOR,
+        )
+        if window_size < 1:
+            raise InvalidOperatorInstanceError(
+                f"{self.op_type} requires window_size >= 1"
+            )
+
+    def temporal_metadata(self, values: Mapping[str, Value]) -> TemporalMetadata:
+        self.validate(values)
+        state_id = self._state_id(default=f"{self.op_id}_{self.STAT_NAME}")
+        buffer_id = self._buffer_id(default=f"{self.op_id}_buffer")
+        output_id = self.outputs[0]
+        return TemporalMetadata(
+            op_id=self.op_id,
+            op_type=self.op_type,
+            stateful=True,
+            state_reads=(state_id, buffer_id),
+            state_writes=(state_id, buffer_id),
+            buffers=(buffer_id,),
+            lag_cycles=1,
+            window_size=self._window_size(),
+            fixed_point_ranges=_fixed_point_ranges(self.attrs, (output_id, state_id)),
+        )
+
+    def estimate_fpga_cost(self, values: Mapping[str, Value]) -> FPGACost:
+        work = max(1, _shape_product(self._output_value(values).shape))
+        window_size = self._window_size()
+        return FPGACost(
+            latency_cycles=max(1, work * 2),
+            initiation_interval=1,
+            dsp=max(1, work),
+            bram=max(1, (work * window_size + 255) // 256),
+            lut=max(2, work * 2),
+            ff=max(2, work * 2),
+            metadata={"heuristic": self.STAT_NAME, "window_size": window_size},
+        )
+
+    def _window_size(self) -> int:
+        return self._optional_int_attr("window_size", 1)
+
+
+class RollingMean(_RollingStat):
+    """Streaming rolling mean over a causal window."""
+
+    OP_TYPE = "RollingMean"
+    STAT_NAME = "rolling_mean"
+
+
+class RollingVar(_RollingStat):
+    """Streaming rolling variance over a causal window."""
+
+    OP_TYPE = "RollingVar"
+    STAT_NAME = "rolling_var"
+
+    def estimate_fpga_cost(self, values: Mapping[str, Value]) -> FPGACost:
+        base = super().estimate_fpga_cost(values)
+        return FPGACost(
+            latency_cycles=base.latency_cycles + self._output_work(values),
+            initiation_interval=base.initiation_interval,
+            dsp=base.dsp + max(1, self._output_work(values)),
+            bram=base.bram,
+            lut=base.lut + max(1, self._output_work(values)),
+            ff=base.ff + max(1, self._output_work(values)),
+            metadata={"heuristic": self.STAT_NAME, "window_size": self._window_size()},
+        )
+
+
+class ScanCell(TemporalOperator):
+    """Placeholder bridge for lowered scan/loop bodies."""
+
+    OP_TYPE = "ScanCell"
+
+    def validate(self, values: Mapping[str, Value]) -> None:
+        self._require_input_count(range(1, 65))
+        self._require_output_count(range(1, 65))
+        for input_value in self._input_values(values):
+            self._require_scalar_or_tensor(input_value, "input")
+        for output_id in self.outputs:
+            output_value = self._lookup_value(values, output_id, "output")
+            self._require_scalar_or_tensor(output_value, "output")
+
+    def temporal_metadata(self, values: Mapping[str, Value]) -> TemporalMetadata:
+        self.validate(values)
+        state_ids = tuple(self._state_ids())
+        return TemporalMetadata(
+            op_id=self.op_id,
+            op_type=self.op_type,
+            stateful=bool(state_ids),
+            state_reads=state_ids,
+            state_writes=state_ids,
+            lag_cycles=1 if state_ids else 0,
+            fixed_point_ranges=_fixed_point_ranges(self.attrs, self.outputs),
+        )
+
+    def estimate_fpga_cost(self, values: Mapping[str, Value]) -> FPGACost:
+        work = sum(
+            max(
+                1,
+                _shape_product(self._lookup_value(values, output_id, "output").shape),
+            )
+            for output_id in self.outputs
+        )
+        return FPGACost(
+            latency_cycles=max(1, work),
+            initiation_interval=1,
+            lut=max(1, work),
+            ff=max(1, work),
+            metadata={"heuristic": "scan_cell"},
+        )
+
+
+def _fixed_point_ranges(
+    attrs: Mapping[str, object], value_ids: Sequence[str]
+) -> dict[str, FixedPointRange]:
+    ranges: dict[str, FixedPointRange] = {}
+    raw_ranges = attrs.get("fixed_point_ranges", {})
+    if not isinstance(raw_ranges, Mapping):
+        raise InvalidOperatorInstanceError(
+            "fixed_point_ranges must be a mapping from value id to range metadata"
+        )
+
+    for value_id in value_ids:
+        range_data = raw_ranges.get(value_id)
+        if isinstance(range_data, Mapping):
+            minimum = range_data.get("minimum")
+            maximum = range_data.get("maximum")
+            signed = range_data.get("signed", True)
+            if isinstance(minimum, (int, float)) and isinstance(maximum, (int, float)):
+                ranges[value_id] = FixedPointRange(
+                    minimum=float(minimum),
+                    maximum=float(maximum),
+                    signed=bool(signed),
+                )
+    return ranges
+
+
+def _string_attr(attrs: Mapping[str, object], name: str, default: str) -> str:
+    value = attrs.get(name, default)
+    if not isinstance(value, str) or not value.strip():
+        raise InvalidOperatorInstanceError(f"{name} must be a non-empty string")
+    return value
+
+
+def _string_sequence_attr(attrs: Mapping[str, object], name: str) -> list[str]:
+    value = attrs.get(name, ())
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise InvalidOperatorInstanceError(f"{name} must be a sequence of strings")
+    result = []
+    for idx, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise InvalidOperatorInstanceError(
+                f"{name}[{idx}] must be a non-empty string"
+            )
+        result.append(item)
+    return result
+
+
+def register_temporal_builtin_operators(registry: OperatorRegistry) -> None:
+    for operator_cls in TEMPORAL_BUILTIN_OPERATORS:
+        registry.register(operator_cls)
+
+
+TEMPORAL_BUILTIN_OPERATORS = [
+    TemporalAdd,
+    TemporalMatMul,
+    Delay,
+    RollingWindow,
+    RollingMean,
+    RollingVar,
+    ScanCell,
+]
+
+TEMPORAL_BUILTIN_OPERATOR_TYPES = [
+    operator_cls.operator_type() for operator_cls in TEMPORAL_BUILTIN_OPERATORS
+]
+
+
+__all__ = [
+    "Delay",
+    "FixedPointRange",
+    "RollingMean",
+    "RollingVar",
+    "RollingWindow",
+    "ScanCell",
+    "TEMPORAL_BUILTIN_OPERATORS",
+    "TEMPORAL_BUILTIN_OPERATOR_TYPES",
+    "TemporalAdd",
+    "TemporalMatMul",
+    "TemporalMetadata",
+    "TemporalOperator",
+    "register_temporal_builtin_operators",
+]

--- a/src/tempo_dag/parsers/onnx/parser.py
+++ b/src/tempo_dag/parsers/onnx/parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import onnx
@@ -10,6 +11,28 @@ from tempo_dag.ir.value import Value, ValueType
 
 if TYPE_CHECKING:
     from tempo_dag.ir.registry import OperatorRegistry
+
+
+@dataclass(frozen=True)
+class ONNXTemporalPattern:
+    """Detected ONNX structure that should lower through temporal IR."""
+
+    node_name: str
+    op_type: str
+    inputs: tuple[str, ...]
+    outputs: tuple[str, ...]
+    stateful_inputs: tuple[str, ...]
+    body_node_count: int = 0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "node_name": self.node_name,
+            "op_type": self.op_type,
+            "inputs": list(self.inputs),
+            "outputs": list(self.outputs),
+            "stateful_inputs": list(self.stateful_inputs),
+            "body_node_count": self.body_node_count,
+        }
 
 
 class ONNXParser:
@@ -202,6 +225,36 @@ class ONNXParser:
 
         return ir_graph
 
+    def detect_temporal_patterns(
+        self, model: onnx.ModelProto
+    ) -> list[ONNXTemporalPattern]:
+        """Identify ONNX nodes that represent loops, scans, or recurrent state."""
+
+        patterns = []
+        for node in model.graph.node:
+            if node.op_type in {"Scan", "Loop"}:
+                patterns.append(
+                    ONNXTemporalPattern(
+                        node_name=node.name or f"{node.op_type}_{len(patterns)}",
+                        op_type=node.op_type,
+                        inputs=tuple(node.input),
+                        outputs=tuple(node.output),
+                        stateful_inputs=_loop_state_inputs(node),
+                        body_node_count=_body_node_count(node),
+                    )
+                )
+            elif node.op_type in {"LSTM", "GRU", "RNN"}:
+                patterns.append(
+                    ONNXTemporalPattern(
+                        node_name=node.name or f"{node.op_type}_{len(patterns)}",
+                        op_type=node.op_type,
+                        inputs=tuple(node.input),
+                        outputs=tuple(node.output),
+                        stateful_inputs=_recurrent_state_inputs(node),
+                    )
+                )
+        return patterns
+
     def _get_onnx_shape(self, tensor_type) -> list[int]:
         shape = []
         for dim in tensor_type.shape.dim:
@@ -239,3 +292,32 @@ class ONNXParser:
         if attr.strings:
             return [s.decode("utf-8") for s in attr.strings]
         return None
+
+
+def _body_node_count(node: onnx.NodeProto) -> int:
+    for attr in node.attribute:
+        if attr.name == "body" and attr.HasField("g"):
+            return len(attr.g.node)
+    return 0
+
+
+def _loop_state_inputs(node: onnx.NodeProto) -> tuple[str, ...]:
+    if node.op_type == "Loop":
+        return tuple(input_id for input_id in node.input[2:] if input_id)
+    if node.op_type == "Scan":
+        num_scan_inputs = _int_attribute(node, "num_scan_inputs", default=0)
+        state_count = max(0, len(node.input) - num_scan_inputs)
+        return tuple(input_id for input_id in node.input[:state_count] if input_id)
+    return ()
+
+
+def _recurrent_state_inputs(node: onnx.NodeProto) -> tuple[str, ...]:
+    # ONNX recurrent ops reserve optional initial state inputs after weights/biases.
+    return tuple(input_id for input_id in node.input[5:] if input_id)
+
+
+def _int_attribute(node: onnx.NodeProto, name: str, *, default: int) -> int:
+    for attr in node.attribute:
+        if attr.name == name and attr.HasField("i"):
+            return int(attr.i)
+    return default

--- a/src/tempo_dag/quantization_config.py
+++ b/src/tempo_dag/quantization_config.py
@@ -20,6 +20,12 @@ class QuantizationType(Enum):
     INTEGER = "integer"
 
 
+class OverflowPolicy(Enum):
+    SATURATE = "saturate"
+    WRAP = "wrap"
+    ERROR = "error"
+
+
 @dataclass(frozen=True)
 class FixedPointSpec:
     integer_bits: int
@@ -62,11 +68,66 @@ class QuantizationSpec:
                 )
 
 
+@dataclass(frozen=True)
+class StateQuantSpec:
+    """Quantization metadata for temporal state carried across timesteps."""
+
+    dtype: str
+    scale: float
+    overflow_policy: OverflowPolicy = OverflowPolicy.SATURATE
+    zero_point: int = 0
+    fixed_point: FixedPointSpec | None = None
+
+    def __post_init__(self) -> None:
+        if not self.dtype.strip():
+            raise ValueError("dtype must be non-empty")
+        if self.scale <= 0:
+            raise ValueError("scale must be positive")
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StateQuantSpec:
+        fixed_point_data = data.get("fixed_point")
+        fixed_point = None
+        if fixed_point_data is not None:
+            if not isinstance(fixed_point_data, dict):
+                raise TypeError("fixed_point must be a dictionary")
+            fixed_point = FixedPointSpec(
+                integer_bits=int(fixed_point_data["integer_bits"]),
+                fractional_bits=int(fixed_point_data["fractional_bits"]),
+            )
+
+        policy_value = data.get("overflow_policy", OverflowPolicy.SATURATE.value)
+        return cls(
+            dtype=str(data["dtype"]),
+            scale=float(data["scale"]),
+            overflow_policy=OverflowPolicy(str(policy_value)),
+            zero_point=int(data.get("zero_point", 0)),
+            fixed_point=fixed_point,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "dtype": self.dtype,
+            "scale": self.scale,
+            "overflow_policy": self.overflow_policy.value,
+            "zero_point": self.zero_point,
+            "fixed_point": (
+                {
+                    "integer_bits": self.fixed_point.integer_bits,
+                    "fractional_bits": self.fixed_point.fractional_bits,
+                }
+                if self.fixed_point is not None
+                else None
+            ),
+        }
+
+
 @dataclass
 class QuantizationConfig:
     global_default: QuantizationSpec
     operator_overrides: dict[str, QuantizationSpec] = field(default_factory=dict)
     tensor_overrides: dict[str, QuantizationSpec] = field(default_factory=dict)
+    state_overrides: dict[str, StateQuantSpec] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> QuantizationConfig:
@@ -109,9 +170,32 @@ class QuantizationConfig:
         for t_name, t_data in data.get("tensors", {}).items():
             tensors[t_name] = parse_spec(t_data, default=global_spec)
 
+        states = {}
+        for state_name, state_data in data.get("states", {}).items():
+            states[state_name] = StateQuantSpec.from_dict(state_data)
+
         return cls(
-            global_default=global_spec, operator_overrides=ops, tensor_overrides=tensors
+            global_default=global_spec,
+            operator_overrides=ops,
+            tensor_overrides=tensors,
+            state_overrides=states,
         )
+
+
+ROLLING_STAT_STATE_PROFILES: dict[str, StateQuantSpec] = {
+    "rolling_mean_q16": StateQuantSpec(
+        dtype="fixed16",
+        scale=2**-8,
+        overflow_policy=OverflowPolicy.SATURATE,
+        fixed_point=FixedPointSpec(integer_bits=8, fractional_bits=8),
+    ),
+    "rolling_var_q24": StateQuantSpec(
+        dtype="fixed24",
+        scale=2**-12,
+        overflow_policy=OverflowPolicy.SATURATE,
+        fixed_point=FixedPointSpec(integer_bits=12, fractional_bits=12),
+    ),
+}
 
 
 def to_fixed_point(value: float, spec: QuantizationSpec) -> int:

--- a/tests/unit/test_numerical_parity.py
+++ b/tests/unit/test_numerical_parity.py
@@ -8,6 +8,7 @@ from tempo_dag.ir.graph import Graph
 from tempo_dag.ir.op import FPGACost, Operator
 from tempo_dag.ir.value import Value, ValueType
 from tempo_dag.numerical_parity import (
+    NumericalParityConfig,
     ONNXRuntimeParityAdapter,
     TensorFlowKerasParityAdapter,
     TorchQuantizedModelSimulator,
@@ -15,8 +16,10 @@ from tempo_dag.numerical_parity import (
 )
 from tempo_dag.quantization_config import (
     FixedPointSpec,
+    OverflowPolicy,
     QuantizationScheme,
     QuantizationSpec,
+    StateQuantSpec,
 )
 
 
@@ -76,6 +79,36 @@ class NonFiniteModel(nn.Module):
         del x
         values = torch.tensor([float("nan")], dtype=torch.float32)
         return self.identity(values)
+
+
+def test_numerical_parity_config_accepts_temporal_state_quantization() -> None:
+    config = NumericalParityConfig.from_input(
+        {
+            "state_quantization": {
+                "hidden": {
+                    "dtype": "fixed16",
+                    "scale": 2**-8,
+                    "overflow_policy": "saturate",
+                    "fixed_point": {"integer_bits": 8, "fractional_bits": 8},
+                },
+                "window": StateQuantSpec(
+                    dtype="fixed24",
+                    scale=2**-12,
+                    overflow_policy=OverflowPolicy.SATURATE,
+                    fixed_point=FixedPointSpec(
+                        integer_bits=12,
+                        fractional_bits=12,
+                    ),
+                ),
+            }
+        }
+    )
+
+    assert config.state_quantization["hidden"].fixed_point == FixedPointSpec(
+        integer_bits=8,
+        fractional_bits=8,
+    )
+    assert config.state_quantization["window"].dtype == "fixed24"
 
 
 class _FakeONNXValueInfo:

--- a/tests/unit/test_onnx_parser.py
+++ b/tests/unit/test_onnx_parser.py
@@ -95,6 +95,89 @@ class TestONNXParser(unittest.TestCase):
         self.assertIn("sigmoid_node", ir_graph.ops)
         self.assertEqual(ir_graph.ops["sigmoid_node"].op_type, "Sigmoid")
 
+    def test_detects_scan_temporal_pattern(self):
+        body_node = helper.make_node("Add", ["state_in", "x_t"], ["state_out"])
+        body = helper.make_graph(
+            [body_node],
+            "scan_body",
+            [
+                helper.make_tensor_value_info("state_in", TensorProto.FLOAT, [4]),
+                helper.make_tensor_value_info("x_t", TensorProto.FLOAT, [4]),
+            ],
+            [helper.make_tensor_value_info("state_out", TensorProto.FLOAT, [4])],
+        )
+        scan = helper.make_node(
+            "Scan",
+            ["initial_state", "sequence"],
+            ["final_state", "scan_outputs"],
+            name="scan_node",
+            num_scan_inputs=1,
+            body=body,
+        )
+        graph = helper.make_graph(
+            [scan],
+            "scan_graph",
+            [
+                helper.make_tensor_value_info("initial_state", TensorProto.FLOAT, [4]),
+                helper.make_tensor_value_info("sequence", TensorProto.FLOAT, [8, 4]),
+            ],
+            [
+                helper.make_tensor_value_info("final_state", TensorProto.FLOAT, [4]),
+                helper.make_tensor_value_info(
+                    "scan_outputs", TensorProto.FLOAT, [8, 4]
+                ),
+            ],
+        )
+        model = helper.make_model(graph, producer_name="scan_test")
+
+        patterns = self.parser.detect_temporal_patterns(model)
+
+        self.assertEqual(len(patterns), 1)
+        self.assertEqual(patterns[0].op_type, "Scan")
+        self.assertEqual(patterns[0].stateful_inputs, ("initial_state",))
+        self.assertEqual(patterns[0].body_node_count, 1)
+
+    def test_detects_loop_temporal_pattern(self):
+        body_node = helper.make_node("Add", ["state_in", "state_in"], ["state_out"])
+        body = helper.make_graph(
+            [body_node],
+            "loop_body",
+            [
+                helper.make_tensor_value_info("iter", TensorProto.INT64, []),
+                helper.make_tensor_value_info("cond_in", TensorProto.BOOL, []),
+                helper.make_tensor_value_info("state_in", TensorProto.FLOAT, [4]),
+            ],
+            [
+                helper.make_tensor_value_info("cond_out", TensorProto.BOOL, []),
+                helper.make_tensor_value_info("state_out", TensorProto.FLOAT, [4]),
+            ],
+        )
+        loop = helper.make_node(
+            "Loop",
+            ["trip_count", "cond", "loop_state"],
+            ["final_state"],
+            name="loop_node",
+            body=body,
+        )
+        graph = helper.make_graph(
+            [loop],
+            "loop_graph",
+            [
+                helper.make_tensor_value_info("trip_count", TensorProto.INT64, []),
+                helper.make_tensor_value_info("cond", TensorProto.BOOL, []),
+                helper.make_tensor_value_info("loop_state", TensorProto.FLOAT, [4]),
+            ],
+            [helper.make_tensor_value_info("final_state", TensorProto.FLOAT, [4])],
+        )
+        model = helper.make_model(graph, producer_name="loop_test")
+
+        patterns = self.parser.detect_temporal_patterns(model)
+
+        self.assertEqual(len(patterns), 1)
+        self.assertEqual(patterns[0].op_type, "Loop")
+        self.assertEqual(patterns[0].stateful_inputs, ("loop_state",))
+        self.assertEqual(patterns[0].body_node_count, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_quantization.py
+++ b/tests/unit/test_quantization.py
@@ -4,10 +4,13 @@ from tempo_dag.ir.graph import Graph
 from tempo_dag.ir.op import FPGACost, Operator
 from tempo_dag.ir.value import Value, ValueType
 from tempo_dag.quantization_config import (
+    ROLLING_STAT_STATE_PROFILES,
     FixedPointSpec,
+    OverflowPolicy,
     QuantizationConfig,
     QuantizationScheme,
     QuantizationSpec,
+    StateQuantSpec,
     apply_quantization_config,
     compute_quant_params,
     to_fixed_point,
@@ -194,3 +197,56 @@ def test_priority_tensor_over_operator():
         graph.values["v1"].quant is not None
     ), "v1.quant was not set by apply_quantization_config"
     assert graph.values["v1"].quant["bit_width"] == 12
+
+
+def test_state_quant_spec_parses_temporal_state_metadata():
+    spec = StateQuantSpec.from_dict(
+        {
+            "dtype": "fixed16",
+            "scale": 0.125,
+            "zero_point": -1,
+            "overflow_policy": "saturate",
+            "fixed_point": {"integer_bits": 6, "fractional_bits": 10},
+        }
+    )
+
+    assert spec.dtype == "fixed16"
+    assert spec.scale == 0.125
+    assert spec.zero_point == -1
+    assert spec.overflow_policy is OverflowPolicy.SATURATE
+    assert spec.fixed_point == FixedPointSpec(integer_bits=6, fractional_bits=10)
+    assert spec.to_dict()["overflow_policy"] == "saturate"
+
+
+def test_quantization_config_parses_state_overrides():
+    config = QuantizationConfig.from_dict(
+        {
+            "global": {
+                "bit_width": 8,
+                "fixed_point": {"integer_bits": 4, "fractional_bits": 4},
+            },
+            "states": {
+                "rolling_sum": {
+                    "dtype": "fixed24",
+                    "scale": 2**-12,
+                    "overflow_policy": "saturate",
+                    "fixed_point": {"integer_bits": 12, "fractional_bits": 12},
+                }
+            },
+        }
+    )
+
+    assert config.state_overrides["rolling_sum"].dtype == "fixed24"
+    assert config.state_overrides["rolling_sum"].fixed_point == FixedPointSpec(
+        integer_bits=12,
+        fractional_bits=12,
+    )
+
+
+def test_rolling_stat_state_profiles_are_ready_for_temporal_ops():
+    assert ROLLING_STAT_STATE_PROFILES["rolling_mean_q16"].overflow_policy is (
+        OverflowPolicy.SATURATE
+    )
+    assert ROLLING_STAT_STATE_PROFILES["rolling_var_q24"].fixed_point == (
+        FixedPointSpec(integer_bits=12, fractional_bits=12)
+    )

--- a/tests/unit/test_temporal_builtins.py
+++ b/tests/unit/test_temporal_builtins.py
@@ -1,0 +1,172 @@
+import pytest
+
+from tempo_dag.ir.op import FPGACost, InvalidOperatorInstanceError
+from tempo_dag.ir.registry import OperatorRegistry
+from tempo_dag.ir.value import Value, ValueType
+from tempo_dag.ops.temporal_builtins import (
+    Delay,
+    RollingMean,
+    RollingVar,
+    RollingWindow,
+    TemporalAdd,
+    TemporalMatMul,
+    register_temporal_builtin_operators,
+)
+
+
+def make_tensor(
+    value_id: str,
+    shape: list[int],
+    axes: list[str] | None = None,
+    dtype: str = "float32",
+) -> Value:
+    if axes is None:
+        axes = [f"axis_{idx}" for idx in range(len(shape))]
+    return Value(
+        value_id=value_id,
+        vtype=ValueType.TENSOR,
+        dtype=dtype,
+        shape=shape,
+        axes=axes,
+    )
+
+
+def test_temporal_add_and_matmul_report_stateless_metadata() -> None:
+    add_values = {
+        "lhs": make_tensor("lhs", [2, 3], ["batch", "feature"]),
+        "rhs": make_tensor("rhs", [2, 3], ["batch", "feature"]),
+        "out": make_tensor("out", [2, 3], ["batch", "feature"]),
+    }
+    add = TemporalAdd(
+        op_id="add_0",
+        inputs=["lhs", "rhs"],
+        outputs=["out"],
+        attrs={"fixed_point_ranges": {"out": {"minimum": -2.0, "maximum": 2.0}}},
+    )
+
+    metadata = add.temporal_metadata(add_values)
+
+    assert metadata.stateful is False
+    assert metadata.state_reads == ()
+    assert metadata.fixed_point_ranges["out"].minimum == -2.0
+
+    matmul_values = {
+        "lhs": make_tensor("lhs", [2, 3], ["rows", "inner"]),
+        "rhs": make_tensor("rhs", [3, 4], ["inner", "cols"]),
+        "out": make_tensor("out", [2, 4], ["rows", "cols"]),
+    }
+    matmul = TemporalMatMul(op_id="matmul_0", inputs=["lhs", "rhs"], outputs=["out"])
+
+    assert matmul.temporal_metadata(matmul_values).to_dict()["stateful"] is False
+
+
+def test_delay_requires_positive_lag_and_threads_buffer_state() -> None:
+    values = {
+        "x": make_tensor("x", [4], ["feature"]),
+        "y": make_tensor("y", [4], ["feature"]),
+    }
+    delay = Delay(
+        op_id="delay_0",
+        inputs=["x"],
+        outputs=["y"],
+        attrs={"lag_cycles": 3, "buffer_id": "x_delay"},
+    )
+
+    delay.validate(values)
+    metadata = delay.temporal_metadata(values)
+
+    assert metadata.stateful is True
+    assert metadata.state_reads == ("x_delay",)
+    assert metadata.state_writes == ("x_delay",)
+    assert metadata.lag_cycles == 3
+    assert delay.estimate_fpga_cost(values) == FPGACost(
+        latency_cycles=1,
+        initiation_interval=1,
+        bram=1,
+        lut=2,
+        ff=4,
+        metadata={"heuristic": "temporal_delay", "lag_cycles": 3},
+    )
+
+    bad_delay = Delay(
+        op_id="bad_delay",
+        inputs=["x"],
+        outputs=["y"],
+        attrs={"lag_cycles": 0},
+    )
+    with pytest.raises(InvalidOperatorInstanceError, match="lag_cycles >= 1"):
+        bad_delay.validate(values)
+
+
+def test_rolling_window_adds_causal_window_axis() -> None:
+    values = {
+        "x": make_tensor("x", [2, 3], ["batch", "feature"]),
+        "window": make_tensor("window", [4, 2, 3], ["window", "batch", "feature"]),
+    }
+    op = RollingWindow(
+        op_id="window_0",
+        inputs=["x"],
+        outputs=["window"],
+        attrs={"window_size": 4},
+    )
+
+    op.validate(values)
+    metadata = op.temporal_metadata(values)
+
+    assert metadata.window_size == 4
+    assert metadata.buffers == ("window_0_buffer",)
+    assert op.estimate_fpga_cost(values).metadata == {
+        "heuristic": "rolling_window",
+        "window_size": 4,
+    }
+
+
+def test_rolling_stats_keep_input_shape_and_report_state_ids() -> None:
+    values = {
+        "x": make_tensor("x", [2, 3], ["batch", "feature"]),
+        "mean": make_tensor("mean", [2, 3], ["batch", "feature"]),
+        "var": make_tensor("var", [2, 3], ["batch", "feature"]),
+    }
+    mean = RollingMean(
+        op_id="mean_0",
+        inputs=["x"],
+        outputs=["mean"],
+        attrs={"window_size": 8, "state_id": "running_sum"},
+    )
+    var = RollingVar(
+        op_id="var_0",
+        inputs=["x"],
+        outputs=["var"],
+        attrs={"window_size": 8, "state_id": "running_var"},
+    )
+
+    mean.validate(values)
+    var.validate(values)
+
+    assert mean.temporal_metadata(values).state_reads == (
+        "running_sum",
+        "mean_0_buffer",
+    )
+    assert var.temporal_metadata(values).state_writes == (
+        "running_var",
+        "var_0_buffer",
+    )
+    assert var.estimate_fpga_cost(values).metadata == {
+        "heuristic": "rolling_var",
+        "window_size": 8,
+    }
+
+
+def test_temporal_builtins_register_with_operator_registry() -> None:
+    registry = OperatorRegistry()
+
+    register_temporal_builtin_operators(registry)
+
+    operator = registry.create(
+        "Delay",
+        op_id="delay_0",
+        inputs=["x"],
+        outputs=["y"],
+        attrs={"lag_cycles": 2},
+    )
+    assert isinstance(operator, Delay)


### PR DESCRIPTION
## Summary
- Add temporal operator bridge primitives for stateless Add/MatMul and stateful Delay, RollingWindow, RollingMean, RollingVar, and ScanCell.
- Add temporal state quantization specs, rolling-stat fixed-point profiles, and NumericalParityConfig state quantization support.
- Add ONNX temporal pattern detection for Scan, Loop, and recurrent nodes.
- Mark Week 2 roadmap tasks complete.

## Verification
- `python -m black --check .`
- `python -m ruff check .`
- `python -m pyrefly check`
- `python -m pytest -q`