### PR TITLE
docs: add open source project guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Report incorrect behavior, failed validation, or broken generated artifacts
+title: "bug: "
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+What went wrong?
+
+## Reproduction
+
+```bash
+
+```
+
+## Expected Behavior
+
+What should have happened?
+
+## Actual Behavior
+
+What happened instead?
+
+## Environment
+
+- OS:
+- Python version:
+- Branch or commit:
+- Relevant dependency versions:
+
+## Artifacts
+
+Attach or link any model, trace, generated HLS, report, or log needed to debug
+the issue.

--- a/.github/ISSUE_TEMPLATE/design_proposal.md
+++ b/.github/ISSUE_TEMPLATE/design_proposal.md
@@ -1,0 +1,31 @@
+---
+name: Design proposal
+about: Propose a compiler, IR, scheduling, HLS, or verification design change
+title: "design: "
+labels: design
+assignees: ""
+---
+
+## Proposal
+
+Describe the design change.
+
+## Motivation
+
+Why is this needed now?
+
+## Alternatives Considered
+
+What other approaches were considered?
+
+## Impact
+
+- IR semantics:
+- Optimizer behavior:
+- HLS/code generation:
+- Verification:
+- Documentation/tests:
+
+## Open Questions
+
+- 

--- a/.github/ISSUE_TEMPLATE/roadmap_task.md
+++ b/.github/ISSUE_TEMPLATE/roadmap_task.md
@@ -1,0 +1,29 @@
+---
+name: Roadmap task
+about: Track implementation work tied to the TempoDAG milestone plan
+title: "roadmap: "
+labels: roadmap
+assignees: ""
+---
+
+## Milestone
+
+Which milestone in `docs/roadmap.md` does this support?
+
+## Goal
+
+What should be true when this task is complete?
+
+## Deliverables
+
+- [ ] 
+
+## Validation
+
+- [ ] Tests added or updated
+- [ ] Documentation updated
+- [ ] Generated artifacts or reports updated, if applicable
+
+## Notes
+
+Any design constraints, references, or known risks.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+- 
+
+## Validation
+
+- [ ] `python -m ruff check src tests`
+- [ ] `python -m black --check .`
+- [ ] `python -m pytest -q`
+- [ ] Documentation updated, if behavior or public workflow changed
+
+## Roadmap Alignment
+
+Which milestone or issue does this support?
+
+- 
+
+## Notes For Reviewers
+
+- 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing To TempoDAG
+
+TempoDAG is early-stage compiler infrastructure for stateful temporal dataflow
+and FPGA-oriented HLS generation. Contributions are welcome, especially when
+they keep the project testable, documented, and aligned with the roadmap.
+
+## Project Priorities
+
+Current work is guided by the milestone plan in [docs/roadmap.md](docs/roadmap.md):
+
+- Precise temporal execution semantics and HLS hardware contracts.
+- Graph-level HLS artifact generation for representative streaming pipelines.
+- Scheduling, cost modeling, temporal graph optimization, and HLS directive
+  optimization.
+- Fixed-point, HLS C simulation, and eventually RTL or board-level parity.
+
+Please avoid broad model-zoo expansion unless it supports one of those
+milestones.
+
+## Development Setup
+
+TempoDAG currently targets Python 3.12.
+
+```powershell
+py -3.12 -m venv .venv
+. .venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+scripts\setup-hooks.ps1
+```
+
+On Linux or macOS:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+./scripts/setup-hooks.sh
+```
+
+## Local Checks
+
+Before opening a pull request, run:
+
+```bash
+python -m ruff check src tests
+python -m black --check .
+python -m pytest -q
+```
+
+If a change touches generated HLS, temporal IR, or verification behavior, add
+or update a golden-trace or parity test.
+
+## Pull Request Expectations
+
+- Keep PRs focused around one feature, fix, or documentation update.
+- Include tests for behavior changes.
+- Update docs when public APIs, roadmap claims, examples, or workflows change.
+- Preserve fixed-point and temporal semantics unless the PR explicitly changes
+  the contract and updates the relevant tests.
+- Do not commit private research notes, local artifacts, generated build
+  products, or board-tool output.
+
+## Code Style
+
+- Use typed dataclasses and explicit validation for IR objects.
+- Keep graph rewrites parameter-preserving: learned weights must remain named
+  constants, state, or immutable parameter blocks.
+- Prefer small, inspectable compiler passes over clever monoliths.
+- Keep HLS generation deterministic so generated artifacts are diff-friendly.
+
+## Reporting Issues
+
+Use GitHub issues for bugs, roadmap tasks, and design proposals. When reporting
+a bug, include the command, expected behavior, actual behavior, Python version,
+and any relevant trace or generated artifact.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # TempoDAG
 
+[![CI](https://github.com/1509Chamma/TempoDAG/actions/workflows/ci.yml/badge.svg)](https://github.com/1509Chamma/TempoDAG/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/1509Chamma/TempoDAG/actions/workflows/codeql.yml/badge.svg)](https://github.com/1509Chamma/TempoDAG/actions/workflows/codeql.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 TempoDAG is a compiler and verification platform for streaming time-series models represented as stateful temporal dataflow graphs. It transforms PyTorch, TensorFlow, or ONNX models into FPGA-friendly intermediate representations with first-class state management, temporal memory planning, and fixed-point correctness verification.
 
 Rather than treating time-series workloads as ordinary DAGs, TempoDAG explicitly models delayed temporal dependencies, rolling buffers, stateful processing, and streaming optimization targets like initiation interval and steady-state behavior.
@@ -7,6 +11,22 @@ Rather than treating time-series workloads as ordinary DAGs, TempoDAG explicitly
 It is not yet a full "train model, emit bitstream, deploy to board" toolchain.
 The current focus is building a reliable temporal compiler foundation with
 first-class state and delayed-edge semantics before scaling to complex models.
+
+## Project Maturity
+
+TempoDAG is pre-release research infrastructure. The repository is useful for
+exploring temporal IR, parser lowering, fixed-point verification, generated HLS
+artifacts, and compiler-roadmap experiments. It should not yet be treated as a
+production deployment toolchain or a stable public API.
+
+The current open-source standard is:
+
+- Keep claims tied to runnable tests, generated artifacts, or documented
+  milestones.
+- Keep roadmap issues aligned with [docs/roadmap.md](docs/roadmap.md).
+- Preserve a clean verification path for temporal semantics and fixed-point
+  behavior.
+- Prefer focused, reviewable compiler passes over broad rewrites.
 
 The repo uses a `src/` layout on disk, but `src` is not part of the public
 import path. For IR-facing code, prefer package imports such as
@@ -105,10 +125,19 @@ Run the same core checks used during development:
 - [Documentation Index](docs/README.md)
 - [Architecture](docs/architecture.md)
 - [Calibration Guide](docs/calibration.md)
+- [Contributing Guide](CONTRIBUTING.md)
 - [Development Guide](docs/development.md)
 - [Environment Setup](docs/environment-setup.md)
+- [Security Policy](SECURITY.md)
 - [Temporal Quickstart](docs/temporal-quickstart.md)
 - [Roadmap](docs/roadmap.md)
+
+## Contributing
+
+Contributions are welcome while the project is taking shape. Start with
+[CONTRIBUTING.md](CONTRIBUTING.md), pick work that supports the roadmap, and
+open an issue or design proposal for changes that affect temporal semantics,
+HLS interfaces, optimization behavior, or verification guarantees.
 
 ## Future Efforts
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+TempoDAG is research-stage compiler infrastructure. It is not currently
+intended for production deployment in safety-critical or financially regulated
+systems.
+
+## Supported Versions
+
+Security fixes are applied to the `main` branch. There are no released stable
+versions yet.
+
+## Reporting A Vulnerability
+
+Please report suspected vulnerabilities privately instead of opening a public
+issue. Use GitHub's private vulnerability reporting if it is enabled for the
+repository, or contact the maintainer listed on the repository profile.
+
+Useful reports include:
+
+- Affected file, workflow, parser, or generated artifact.
+- Reproduction steps.
+- Expected impact.
+- Suggested mitigation, if known.
+
+## Scope
+
+Security-sensitive areas include:
+
+- Parsing untrusted ONNX, TensorFlow, or PyTorch-exported models.
+- Generated C++/HLS code and script emission.
+- GitHub Actions workflows and dependency automation.
+- Future board, RTL, or toolchain integration scripts.
+
+Do not run untrusted models, generated code, or vendor-tool scripts without
+reviewing them first.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,11 +13,14 @@ with stateful temporal dataflow.
   criteria
 
 **Contributing or extending?**
+- [Contributing Guide](../CONTRIBUTING.md): Pull request expectations and local
+  validation
 - [Development Guide](development.md): Day-to-day workflow and extension
   patterns
 - [Calibration Guide](calibration.md): Quantization and representative dataset
   sampling
 - [Environment Setup](environment-setup.md): Local environment and hook setup
+- [Security Policy](../SECURITY.md): Supported security reporting process
 
 **Reference**
 - [Roadmap](roadmap.md): Stage-based implementation direction
@@ -34,9 +37,10 @@ with stateful temporal dataflow.
 3. Skim [30-Day Roadmap](roadmap-30day.md) for what is being built next.
 
 ### Contributing
-1. Read [Development Guide](development.md) for workflow.
-2. Check [30-Day Roadmap](roadmap-30day.md) for current priorities.
-3. Read section docs, such as the Calibration Guide, as needed.
+1. Read [Contributing Guide](../CONTRIBUTING.md) for expectations.
+2. Read [Development Guide](development.md) for workflow.
+3. Check [Roadmap](roadmap.md) for current milestones.
+4. Read section docs, such as the Calibration Guide, as needed.
 
 ### Understanding the Vision
 1. [Platform Vision](platform-vision.md): strategic alignment with research


### PR DESCRIPTION
## Summary

- Adds contribution and security guidance for the public TempoDAG repo
- Adds issue templates for bugs, roadmap tasks, and design proposals
- Adds a pull request checklist aligned with local checks and roadmap work
- Updates README/docs index with maturity, governance, and contribution entry points

## GitHub metadata

- Updated the repository description to the broader temporal DAG/HLS platform positioning
- Added repository topics for FPGA, HLS, compiler, time-series, dataflow, ONNX, verification, and AMD
- Added roadmap/design/HLS/verification/optimizer labels
- Created roadmap issues #96-#101 because there were no open old issues to update

## Validation

- git diff --check