### PR TITLE
ci: cache Python virtual environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -92,7 +93,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: ${{ runner.os }}-python-3.12-venv-${{ hashFiles('requirements.txt') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('requirements.txt') }}
 
       - name: Install Python dependencies
         if: steps.venv-cache.outputs.cache-hit != 'true'
@@ -174,6 +175,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -183,7 +185,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: ${{ runner.os }}-python-3.12-venv-${{ hashFiles('requirements.txt') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('requirements.txt') }}
 
       - name: Install Python dependencies
         if: steps.venv-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,14 +86,23 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: requirements.txt
+
+      - name: Restore Python virtual environment
+        id: venv-cache
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ runner.os }}-python-3.12-venv-${{ hashFiles('requirements.txt') }}
 
       - name: Install Python dependencies
-        run: python -m pip install -r requirements.txt
+        if: steps.venv-cache.outputs.cache-hit != 'true'
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -r requirements.txt
 
       - name: Run pyrefly
-        run: pyrefly check
+        run: .venv/bin/pyrefly check
 
   build:
     name: Build
@@ -168,11 +177,20 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: requirements.txt
+
+      - name: Restore Python virtual environment
+        id: venv-cache
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ runner.os }}-python-3.12-venv-${{ hashFiles('requirements.txt') }}
 
       - name: Install Python dependencies
-        run: python -m pip install -r requirements.txt
+        if: steps.venv-cache.outputs.cache-hit != 'true'
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -r requirements.txt
 
       - name: Run test suite
-        run: PYTHONPATH=src python -m pytest -q
+        run: PYTHONPATH=src .venv/bin/python -m pytest -q


### PR DESCRIPTION
## Summary

- Replaces repeated full pip installs in Python Quality and Test with a cached .venv keyed by OS, Python version, and requirements.txt
- Rebuilds the virtual environment automatically when requirements.txt changes
- Runs pyrefly and pytest through the cached virtual environment

## Expected behavior

- First run with a new requirements hash builds and saves .venv
- Later runs with the same requirements hash restore .venv and skip dependency installation
- Cold cache still works from scratch

## Validation

- git diff --check