### PR TITLE
Define temporal execution contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,8 @@ with stateful temporal dataflow.
 - [Competition Submission Strategy](submission-strategy.md): AMD-focused demo
   and packaging plan
 - [Temporal IR Guide](temporal-ir-guide.md): Stateful dataflow concepts
+- [Temporal Execution Contract](temporal-execution-contract.md): Execution and
+  HLS lowering semantics
 - [Quickstart](temporal-quickstart.md): First temporal model demo
 
 ## Reading Order

--- a/docs/temporal-execution-contract.md
+++ b/docs/temporal-execution-contract.md
@@ -215,3 +215,16 @@ Every optimizer pass must preserve:
 
 Any optimization that changes latency must update the generated schedule and
 report so parity checking uses the correct timestep alignment.
+
+## Reference Processes
+
+The canonical M1 reference processes live in
+`tempo_dag.examples.reference_processes`:
+
+- `delay_line_process()` exercises a fixed positive-lag dependency.
+- `recurrent_state_process()` exercises legal recurrence through lag-one state.
+- `rolling_window_process()` exercises buffer warm-up and ring-buffer storage.
+- `initialized_state_process()` exercises metadata-driven reset behavior.
+
+These examples are intentionally small so scheduler, optimizer, HLS, and
+verification tests can share the same semantic fixtures.

--- a/docs/temporal-execution-contract.md
+++ b/docs/temporal-execution-contract.md
@@ -1,0 +1,217 @@
+# Temporal Execution And HLS Contract
+
+This document is the implementation contract for TempoDAG temporal processes.
+It defines how a `Process` executes over time and how temporal dependencies
+lower into FPGA-oriented HLS storage and interfaces.
+
+The contract is intentionally conservative. Optimizers and backends may improve
+the schedule or storage layout, but they must preserve these observable
+semantics.
+
+## Scope
+
+This contract applies to `tempo_dag.ir_temporal.Process` and the first Vitis
+HLS-oriented backend. It covers:
+
+- Reset, warm-up, steady-state, flush, and stream termination behavior.
+- State and buffer read/write ordering.
+- `Edge0` and `EdgeDelta` execution meaning.
+- Legal lowering of temporal dependencies to HLS storage.
+- The minimum generated HLS block interface expected by later backends.
+
+## Temporal Process Model
+
+A `Process` is evaluated as a sequence of timesteps:
+
+```text
+t = 0, 1, 2, ...
+```
+
+At each timestep, the process consumes zero or more stream inputs, reads
+persistent state and bounded history, evaluates one or more same-timestep
+kernels, produces outputs, and commits state or buffer updates for future
+timesteps.
+
+The initial implementation assumes a single logical clock named `main`.
+Multiple clocks are represented in the IR but are not yet part of the execution
+contract.
+
+## Component Semantics
+
+### Kernel
+
+A `Kernel` wraps an acyclic same-timestep `tempo_dag.ir.Graph`.
+
+At timestep `t`, every kernel observes values for timestep `t` plus any
+explicitly connected state or buffer views. A kernel must not observe writes
+that are committed later in the same timestep unless an explicit `Edge0`
+dependency defines that same-timestep value flow.
+
+### State
+
+`StateSpec` represents persistent values such as hidden state, running
+statistics, or recurrent cell state.
+
+At timestep `t`:
+
+1. State reads observe the committed state from before timestep `t` begins.
+2. Kernels may compute next-state values during timestep `t`.
+3. State writes commit after all same-timestep computation for `t` completes.
+4. The committed value becomes visible to timestep `t + 1` and later.
+
+This two-phase read/commit behavior prevents accidental same-timestep feedback
+loops through state.
+
+### Buffer
+
+`BufferSpec` represents bounded history such as a delay line, ring buffer, or
+rolling window.
+
+At timestep `t`:
+
+1. Buffer reads observe samples committed before timestep `t`.
+2. New samples are appended or written during timestep `t`.
+3. Buffer pointer and storage updates commit after same-timestep computation.
+4. The new history is visible starting at timestep `t + 1`.
+
+Buffers with insufficient history during warm-up must use the documented
+initialization policy in metadata or the backend default of zero-fill.
+
+## Edge Semantics
+
+### `Edge0`
+
+`Edge0(source, target)` is a same-timestep dependency:
+
+```text
+source[t] -> target[t]
+```
+
+All `Edge0` dependencies in a process must form a DAG. This makes every
+timestep schedulable without requiring unbounded combinational feedback.
+
+Legal HLS lowerings include:
+
+- C++ local variables for scalar or small tensor values.
+- Wires or direct function-call arguments in generated code.
+- HLS streams inside a `DATAFLOW` region when producer and consumer are
+  separate processes or functions.
+
+`Edge0` must not be lowered to persistent storage unless the storage is purely
+an implementation detail and does not add visible latency.
+
+### `EdgeDelta`
+
+`EdgeDelta(source, target, lag_cycles=n)` is a positive-lag dependency:
+
+```text
+source[t - n] -> target[t]
+```
+
+`lag_cycles` must be at least `1`. Any feedback cycle in the full temporal graph
+must include at least one `EdgeDelta`.
+
+Legal HLS lowerings include:
+
+- Registers for lag-one scalar state.
+- Shift registers for short fixed delays.
+- FIFOs for stream-aligned delays.
+- Ring buffers for rolling windows or bounded history.
+- BRAM, URAM, or external memory for larger histories.
+
+The chosen storage must preserve ordering, lag, dtype, shape, and reset
+behavior.
+
+## Execution Phases
+
+### Reset
+
+Reset initializes every state and buffer before timestep `0`.
+
+Default reset policy:
+
+- Numeric state values reset to zero unless metadata provides an initializer.
+- Buffers reset to zero-filled history unless metadata provides an initializer.
+- Write pointers reset to the first logical position.
+
+Generated HLS must expose reset behavior either as an explicit reset argument,
+an initialization function, or documented static initialization in the
+testbench flow.
+
+### Warm-Up
+
+Warm-up covers timesteps where delayed dependencies or rolling windows do not
+yet have enough real history.
+
+During warm-up:
+
+- `EdgeDelta` reads beyond available history use the reset/initial history.
+- Buffers report valid history according to their metadata or zero-fill policy.
+- Outputs may be marked warm-up in reports if they depend on incomplete
+  history.
+
+Warm-up must be deterministic and reproducible in golden traces.
+
+### Steady State
+
+Steady state begins once every delay, buffer, and rolling window has enough
+committed history to satisfy its maximum lag or depth.
+
+Optimization metrics such as initiation interval and throughput should be
+reported primarily for steady state.
+
+### Flush
+
+Flush drains any internally buffered output after the final input timestep.
+
+The first backend may report `flush_cycles = 0` for purely combinational or
+state-update-only pipelines. Future backends with HLS streams or multi-stage
+dataflow must report flush cycles explicitly.
+
+### Stream Termination
+
+The process terminates after:
+
+1. All input timesteps have been consumed.
+2. All required state and buffer commits have completed.
+3. All flush outputs have been produced.
+
+Reports and testbenches must state the number of input timesteps, warm-up
+timesteps, flush cycles, and checked output timesteps.
+
+## HLS Block Interface
+
+The baseline generated HLS block for a temporal process should expose a stable
+step-style interface:
+
+```cpp
+void process_step(/* stream inputs, stream outputs, reset/control */);
+```
+
+Minimum interface requirements:
+
+- One call represents one logical timestep unless a generated report says
+  otherwise.
+- Reset behavior is explicit in the generated testbench or function interface.
+- Persistent state and buffer storage are owned by the generated block unless a
+  backend explicitly emits external state ports.
+- The generated testbench must replay the same golden trace used by the
+  fixed-point oracle.
+
+Backends may later emit wider streaming interfaces, `hls::stream` ports,
+AXI-style ports, or external memory interfaces, but those forms must preserve
+the same logical timestep contract.
+
+## Optimizer Obligations
+
+Every optimizer pass must preserve:
+
+- `Edge0` acyclicity within each timestep.
+- Positive lag for every temporal feedback path.
+- State read-before-commit behavior.
+- Buffer read-before-update behavior.
+- Dtype, shape, quantization metadata, and parameter identity.
+- Reset, warm-up, steady-state, flush, and termination observability.
+
+Any optimization that changes latency must update the generated schedule and
+report so parity checking uses the correct timestep alignment.

--- a/docs/temporal-ir-guide.md
+++ b/docs/temporal-ir-guide.md
@@ -93,3 +93,6 @@ This first implementation is structural. It validates process consistency and
 the key temporal DAG invariant. Operator lowering, temporal ONNX parsing,
 state-aware quantization, scheduling, and HLS generation build on this layer in
 later roadmap steps.
+
+For the operational timestep semantics and HLS storage/interface obligations,
+see [Temporal Execution And HLS Contract](temporal-execution-contract.md).

--- a/src/tempo_dag/codegen/hls/temporal_generator.py
+++ b/src/tempo_dag/codegen/hls/temporal_generator.py
@@ -24,11 +24,10 @@ class TemporalHLSArtifact:
 def render_temporal_process_hls(process: Process) -> str:
     """Render a top-level HLS wrapper for a temporal process."""
 
-    process.validate()
+    contract = derive_temporal_execution_contract(process)
     if len(process.kernels) != 1:
         raise ValueError("temporal HLS MVP currently supports exactly one kernel")
 
-    contract = derive_temporal_execution_contract(process)
     kernel = next(iter(process.kernels.values()))
     operator_blocks = []
     for operator in kernel.graph.ops.values():

--- a/src/tempo_dag/codegen/hls/temporal_generator.py
+++ b/src/tempo_dag/codegen/hls/temporal_generator.py
@@ -5,7 +5,11 @@ from os import PathLike
 from pathlib import Path
 
 from tempo_dag.codegen.hls.generator import render_operator_hls
-from tempo_dag.ir_temporal import Process
+from tempo_dag.ir_temporal import (
+    Process,
+    TemporalStorageMapping,
+    derive_temporal_execution_contract,
+)
 from tempo_dag.verification.golden_trace import GoldenTrace, load_golden_trace
 
 
@@ -24,6 +28,7 @@ def render_temporal_process_hls(process: Process) -> str:
     if len(process.kernels) != 1:
         raise ValueError("temporal HLS MVP currently supports exactly one kernel")
 
+    contract = derive_temporal_execution_contract(process)
     kernel = next(iter(process.kernels.values()))
     operator_blocks = []
     for operator in kernel.graph.ops.values():
@@ -50,6 +55,14 @@ def render_temporal_process_hls(process: Process) -> str:
     return "\n".join(
         [
             f"// Temporal process: {process.process_id}",
+            f"// reset_policy: {contract.reset_policy.value}",
+            f"// warmup_timesteps: {contract.warmup_timesteps}",
+            f"// flush_cycles: {contract.flush_cycles}",
+            *_contract_storage_comments(
+                contract.edge_delta_storage,
+                "edge_delta_storage",
+            ),
+            *_contract_storage_comments(contract.buffer_storage, "buffer_storage"),
             *header_blocks,
             "",
             *buffer_blocks,
@@ -62,6 +75,19 @@ def render_temporal_process_hls(process: Process) -> str:
             "",
         ]
     )
+
+
+def _contract_storage_comments(
+    storage: tuple[TemporalStorageMapping, ...],
+    label: str,
+) -> list[str]:
+    comments = []
+    for mapping in storage:
+        comments.append(
+            f"// {label}: {mapping.component_id} -> "
+            f"{mapping.storage_kind.value} latency={mapping.latency_cycles}"
+        )
+    return comments
 
 
 def render_temporal_testbench(

--- a/src/tempo_dag/examples/__init__.py
+++ b/src/tempo_dag/examples/__init__.py
@@ -1,3 +1,10 @@
+from .reference_processes import (
+    delay_line_process,
+    initialized_state_process,
+    recurrent_state_process,
+    rolling_window_process,
+    temporal_reference_processes,
+)
 from .temporal_demo import (
     OUTPUT_DIR,
     RollingMeanConvDemoModel,
@@ -11,5 +18,10 @@ __all__ = [
     "RollingMeanConvDemoModel",
     "TemporalDemoReport",
     "TemporalStepMetric",
+    "delay_line_process",
+    "initialized_state_process",
+    "recurrent_state_process",
+    "rolling_window_process",
     "run_demo",
+    "temporal_reference_processes",
 ]

--- a/src/tempo_dag/examples/reference_processes.py
+++ b/src/tempo_dag/examples/reference_processes.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from tempo_dag.ir.graph import Graph
+from tempo_dag.ir_temporal import (
+    BufferSpec,
+    Edge0,
+    EdgeDelta,
+    Kernel,
+    Process,
+    StateKind,
+    StateSpec,
+)
+
+
+def delay_line_process() -> Process:
+    """Reference graph for a fixed positive-lag temporal dependency."""
+
+    kernel = _empty_kernel("delay_kernel")
+    buffer = BufferSpec(
+        buffer_id="delay_buffer",
+        dtype="float32",
+        shape=(1,),
+        depth=4,
+    )
+    return Process(
+        process_id="reference_delay_line",
+        kernels={kernel.kernel_id: kernel},
+        buffers={buffer.buffer_id: buffer},
+        edge0=[Edge0("delay_buffer", "delay_kernel", value_id="x_t_minus_3")],
+        edge_delta=[
+            EdgeDelta("delay_kernel", "delay_buffer", lag_cycles=3, value_id="x")
+        ],
+    )
+
+
+def recurrent_state_process() -> Process:
+    """Reference graph for legal recurrence through positive-lag state."""
+
+    kernel = _empty_kernel("cell")
+    hidden = StateSpec(
+        state_id="hidden",
+        kind=StateKind.HIDDEN,
+        dtype="float32",
+        shape=(8,),
+    )
+    return Process(
+        process_id="reference_recurrent_state",
+        kernels={kernel.kernel_id: kernel},
+        states={hidden.state_id: hidden},
+        edge0=[Edge0("hidden", "cell", value_id="hidden_prev")],
+        edge_delta=[EdgeDelta("cell", "hidden", lag_cycles=1, value_id="hidden_next")],
+    )
+
+
+def rolling_window_process() -> Process:
+    """Reference graph for bounded window history and same-timestep compute."""
+
+    kernel = _empty_kernel("feature_kernel")
+    window = BufferSpec(
+        buffer_id="rolling_window",
+        dtype="float32",
+        shape=(4,),
+        depth=8,
+        axes=("channel",),
+    )
+    return Process(
+        process_id="reference_rolling_window",
+        kernels={kernel.kernel_id: kernel},
+        buffers={window.buffer_id: window},
+        edge0=[Edge0("rolling_window", "feature_kernel", value_id="window")],
+        edge_delta=[
+            EdgeDelta("feature_kernel", "rolling_window", lag_cycles=1, value_id="x")
+        ],
+    )
+
+
+def initialized_state_process() -> Process:
+    """Reference graph for metadata-driven reset initialization."""
+
+    kernel = _empty_kernel("stateful_kernel")
+    state = StateSpec(
+        state_id="running_mean",
+        kind=StateKind.RUNNING_STAT,
+        dtype="float32",
+        shape=(1,),
+        metadata={"initializer": [0.5]},
+    )
+    return Process(
+        process_id="reference_initialized_state",
+        kernels={kernel.kernel_id: kernel},
+        states={state.state_id: state},
+        edge0=[Edge0("running_mean", "stateful_kernel", value_id="mean_prev")],
+        edge_delta=[
+            EdgeDelta(
+                "stateful_kernel",
+                "running_mean",
+                lag_cycles=1,
+                value_id="mean_next",
+            )
+        ],
+    )
+
+
+def temporal_reference_processes() -> tuple[Process, ...]:
+    """Return the canonical M1 reference temporal processes."""
+
+    return (
+        delay_line_process(),
+        recurrent_state_process(),
+        rolling_window_process(),
+        initialized_state_process(),
+    )
+
+
+def _empty_kernel(kernel_id: str) -> Kernel:
+    return Kernel(
+        kernel_id=kernel_id,
+        graph=Graph(values={}, ops={}, graph_inputs=[], graph_outputs=[]),
+    )

--- a/src/tempo_dag/ir_temporal/__init__.py
+++ b/src/tempo_dag/ir_temporal/__init__.py
@@ -1,3 +1,10 @@
+from .contract import (
+    ResetPolicy,
+    TemporalExecutionContract,
+    TemporalStorageKind,
+    TemporalStorageMapping,
+    derive_temporal_execution_contract,
+)
 from .process import (
     BufferSpec,
     Clock,
@@ -18,8 +25,13 @@ __all__ = [
     "EdgeDelta",
     "Kernel",
     "Process",
+    "ResetPolicy",
     "StateKind",
     "StateSpec",
+    "TemporalExecutionContract",
     "TemporalIRValidationError",
+    "TemporalStorageKind",
+    "TemporalStorageMapping",
+    "derive_temporal_execution_contract",
     "validate_temporal_process",
 ]

--- a/src/tempo_dag/ir_temporal/contract.py
+++ b/src/tempo_dag/ir_temporal/contract.py
@@ -50,7 +50,7 @@ class TemporalExecutionContract:
 
 
 def derive_temporal_execution_contract(process: Process) -> TemporalExecutionContract:
-    """Derive conservative execution metadata from a validated process."""
+    """Validate a process and derive conservative execution metadata."""
 
     process.validate()
     return TemporalExecutionContract(
@@ -113,7 +113,11 @@ def _edge_delta_id(edge: EdgeDelta) -> str:
 def _storage_for_edge_delta(edge: EdgeDelta) -> TemporalStorageKind:
     if edge.lag_cycles == 1:
         return TemporalStorageKind.REGISTER
-    return TemporalStorageKind.SHIFT_REGISTER
+    if edge.lag_cycles <= 64:
+        return TemporalStorageKind.SHIFT_REGISTER
+    if edge.lag_cycles <= 1024:
+        return TemporalStorageKind.FIFO
+    return TemporalStorageKind.RAM
 
 
 def _storage_for_buffer(buffer: BufferSpec) -> TemporalStorageKind:

--- a/src/tempo_dag/ir_temporal/contract.py
+++ b/src/tempo_dag/ir_temporal/contract.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from tempo_dag.ir_temporal.process import BufferSpec, EdgeDelta, Process
+
+
+class ResetPolicy(Enum):
+    """Reset initialization policy for persistent temporal storage."""
+
+    ZERO = "zero"
+    METADATA_INITIALIZER = "metadata_initializer"
+
+
+class TemporalStorageKind(Enum):
+    """Conservative HLS storage choices for temporal dependencies."""
+
+    WIRE = "wire"
+    REGISTER = "register"
+    SHIFT_REGISTER = "shift_register"
+    FIFO = "fifo"
+    RING_BUFFER = "ring_buffer"
+    RAM = "ram"
+
+
+@dataclass(frozen=True)
+class TemporalStorageMapping:
+    """Suggested storage for one temporal component or dependency."""
+
+    component_id: str
+    storage_kind: TemporalStorageKind
+    latency_cycles: int = 0
+
+
+@dataclass(frozen=True)
+class TemporalExecutionContract:
+    """Machine-readable summary of the temporal execution contract."""
+
+    process_id: str
+    reset_policy: ResetPolicy
+    warmup_timesteps: int
+    flush_cycles: int
+    edge_delta_storage: tuple[TemporalStorageMapping, ...]
+    buffer_storage: tuple[TemporalStorageMapping, ...]
+
+    @property
+    def has_warmup(self) -> bool:
+        return self.warmup_timesteps > 0
+
+
+def derive_temporal_execution_contract(process: Process) -> TemporalExecutionContract:
+    """Derive conservative execution metadata from a validated process."""
+
+    process.validate()
+    return TemporalExecutionContract(
+        process_id=process.process_id,
+        reset_policy=_reset_policy(process),
+        warmup_timesteps=max(
+            _max_edge_delta_lag(process.edge_delta),
+            _max_buffer_warmup(process),
+        ),
+        flush_cycles=_flush_cycles(process),
+        edge_delta_storage=tuple(
+            TemporalStorageMapping(
+                component_id=_edge_delta_id(edge),
+                storage_kind=_storage_for_edge_delta(edge),
+                latency_cycles=edge.lag_cycles,
+            )
+            for edge in process.edge_delta
+        ),
+        buffer_storage=tuple(
+            TemporalStorageMapping(
+                component_id=buffer.buffer_id,
+                storage_kind=_storage_for_buffer(buffer),
+                latency_cycles=buffer.depth,
+            )
+            for buffer in process.buffers.values()
+        ),
+    )
+
+
+def _reset_policy(process: Process) -> ResetPolicy:
+    has_initializer = any(
+        "initializer" in component.metadata
+        for component in (*process.states.values(), *process.buffers.values())
+    )
+    if has_initializer:
+        return ResetPolicy.METADATA_INITIALIZER
+    return ResetPolicy.ZERO
+
+
+def _max_edge_delta_lag(edges: list[EdgeDelta]) -> int:
+    return max((edge.lag_cycles for edge in edges), default=0)
+
+
+def _max_buffer_warmup(process: Process) -> int:
+    return max((buffer.depth - 1 for buffer in process.buffers.values()), default=0)
+
+
+def _flush_cycles(process: Process) -> int:
+    value = process.metadata.get("flush_cycles", 0)
+    if not isinstance(value, int) or value < 0:
+        raise ValueError("process metadata 'flush_cycles' must be a non-negative int")
+    return value
+
+
+def _edge_delta_id(edge: EdgeDelta) -> str:
+    value_suffix = f":{edge.value_id}" if edge.value_id else ""
+    return f"{edge.source}->{edge.target}@{edge.lag_cycles}{value_suffix}"
+
+
+def _storage_for_edge_delta(edge: EdgeDelta) -> TemporalStorageKind:
+    if edge.lag_cycles == 1:
+        return TemporalStorageKind.REGISTER
+    return TemporalStorageKind.SHIFT_REGISTER
+
+
+def _storage_for_buffer(buffer: BufferSpec) -> TemporalStorageKind:
+    if buffer.depth <= 2:
+        return TemporalStorageKind.SHIFT_REGISTER
+    if buffer.depth <= 1024:
+        return TemporalStorageKind.RING_BUFFER
+    return TemporalStorageKind.RAM

--- a/tests/unit/test_reference_processes.py
+++ b/tests/unit/test_reference_processes.py
@@ -1,0 +1,54 @@
+from tempo_dag.examples import (
+    delay_line_process,
+    initialized_state_process,
+    recurrent_state_process,
+    rolling_window_process,
+    temporal_reference_processes,
+)
+from tempo_dag.ir_temporal import (
+    ResetPolicy,
+    TemporalStorageKind,
+    derive_temporal_execution_contract,
+)
+
+
+def test_reference_processes_validate() -> None:
+    processes = temporal_reference_processes()
+
+    assert {process.process_id for process in processes} == {
+        "reference_delay_line",
+        "reference_recurrent_state",
+        "reference_rolling_window",
+        "reference_initialized_state",
+    }
+    for process in processes:
+        process.validate()
+
+
+def test_delay_line_reference_exercises_positive_lag_storage() -> None:
+    contract = derive_temporal_execution_contract(delay_line_process())
+
+    assert contract.warmup_timesteps == 3
+    assert contract.edge_delta_storage[0].storage_kind == (
+        TemporalStorageKind.SHIFT_REGISTER
+    )
+
+
+def test_recurrent_state_reference_exercises_register_feedback() -> None:
+    contract = derive_temporal_execution_contract(recurrent_state_process())
+
+    assert contract.warmup_timesteps == 1
+    assert contract.edge_delta_storage[0].storage_kind == TemporalStorageKind.REGISTER
+
+
+def test_rolling_window_reference_exercises_buffer_warmup() -> None:
+    contract = derive_temporal_execution_contract(rolling_window_process())
+
+    assert contract.warmup_timesteps == 7
+    assert contract.buffer_storage[0].storage_kind == TemporalStorageKind.RING_BUFFER
+
+
+def test_initialized_state_reference_exercises_reset_policy() -> None:
+    contract = derive_temporal_execution_contract(initialized_state_process())
+
+    assert contract.reset_policy == ResetPolicy.METADATA_INITIALIZER

--- a/tests/unit/test_temporal_contract.py
+++ b/tests/unit/test_temporal_contract.py
@@ -1,0 +1,138 @@
+import pytest
+
+from tempo_dag.ir.graph import Graph
+from tempo_dag.ir_temporal import (
+    BufferSpec,
+    Edge0,
+    EdgeDelta,
+    Kernel,
+    Process,
+    ResetPolicy,
+    StateKind,
+    StateSpec,
+    TemporalStorageKind,
+    derive_temporal_execution_contract,
+)
+
+
+def _kernel(kernel_id: str = "kernel") -> Kernel:
+    return Kernel(
+        kernel_id=kernel_id,
+        graph=Graph(values={}, ops={}, graph_inputs=[], graph_outputs=[]),
+    )
+
+
+def test_contract_derives_warmup_from_lag_and_buffer_depth() -> None:
+    process = Process(
+        process_id="rolling_recurrence",
+        kernels={"kernel": _kernel()},
+        buffers={
+            "window": BufferSpec(
+                buffer_id="window",
+                dtype="float32",
+                shape=(4,),
+                depth=8,
+            )
+        },
+        states={
+            "hidden": StateSpec(
+                state_id="hidden",
+                kind=StateKind.HIDDEN,
+                dtype="float32",
+                shape=(4,),
+            )
+        },
+        edge0=[Edge0("window", "kernel")],
+        edge_delta=[EdgeDelta("kernel", "hidden", lag_cycles=2)],
+    )
+
+    contract = derive_temporal_execution_contract(process)
+
+    assert contract.process_id == "rolling_recurrence"
+    assert contract.reset_policy == ResetPolicy.ZERO
+    assert contract.warmup_timesteps == 7
+    assert contract.has_warmup
+    assert contract.flush_cycles == 0
+
+
+def test_contract_uses_metadata_initializer_reset_policy() -> None:
+    process = Process(
+        process_id="initialized_state",
+        kernels={"kernel": _kernel()},
+        states={
+            "hidden": StateSpec(
+                state_id="hidden",
+                kind=StateKind.HIDDEN,
+                dtype="float32",
+                shape=(2,),
+                metadata={"initializer": [1.0, 0.0]},
+            )
+        },
+    )
+
+    contract = derive_temporal_execution_contract(process)
+
+    assert contract.reset_policy == ResetPolicy.METADATA_INITIALIZER
+
+
+def test_contract_maps_short_lag_to_register_and_long_lag_to_shift_register() -> None:
+    process = Process(
+        process_id="lag_storage",
+        kernels={"kernel": _kernel()},
+        states={
+            "state": StateSpec(
+                state_id="state",
+                kind=StateKind.HIDDEN,
+                dtype="float32",
+                shape=(1,),
+            )
+        },
+        edge_delta=[
+            EdgeDelta("kernel", "state", lag_cycles=1, value_id="short"),
+            EdgeDelta("state", "kernel", lag_cycles=3, value_id="long"),
+        ],
+    )
+
+    contract = derive_temporal_execution_contract(process)
+    storage = {mapping.component_id: mapping for mapping in contract.edge_delta_storage}
+
+    assert storage["kernel->state@1:short"].storage_kind == TemporalStorageKind.REGISTER
+    assert (
+        storage["state->kernel@3:long"].storage_kind
+        == TemporalStorageKind.SHIFT_REGISTER
+    )
+
+
+def test_contract_maps_buffer_depth_to_storage_kind() -> None:
+    process = Process(
+        process_id="buffer_storage",
+        kernels={"kernel": _kernel()},
+        buffers={
+            "small": BufferSpec("small", dtype="float32", shape=(1,), depth=2),
+            "window": BufferSpec("window", dtype="float32", shape=(1,), depth=16),
+            "large": BufferSpec("large", dtype="float32", shape=(1,), depth=2048),
+        },
+    )
+
+    contract = derive_temporal_execution_contract(process)
+    storage = {
+        mapping.component_id: mapping.storage_kind
+        for mapping in contract.buffer_storage
+    }
+
+    assert storage == {
+        "small": TemporalStorageKind.SHIFT_REGISTER,
+        "window": TemporalStorageKind.RING_BUFFER,
+        "large": TemporalStorageKind.RAM,
+    }
+
+
+def test_contract_rejects_invalid_flush_cycle_metadata() -> None:
+    process = Process(
+        process_id="bad_flush",
+        kernels={"kernel": _kernel()},
+        metadata={"flush_cycles": -1},
+    )
+
+    with pytest.raises(ValueError, match="flush_cycles"):
+        derive_temporal_execution_contract(process)

--- a/tests/unit/test_temporal_contract.py
+++ b/tests/unit/test_temporal_contract.py
@@ -103,6 +103,31 @@ def test_contract_maps_short_lag_to_register_and_long_lag_to_shift_register() ->
     )
 
 
+def test_contract_maps_large_temporal_lag_to_fifo_or_ram() -> None:
+    process = Process(
+        process_id="large_lag_storage",
+        kernels={"kernel": _kernel()},
+        states={
+            "state": StateSpec(
+                state_id="state",
+                kind=StateKind.HIDDEN,
+                dtype="float32",
+                shape=(1,),
+            )
+        },
+        edge_delta=[
+            EdgeDelta("kernel", "state", lag_cycles=128, value_id="medium"),
+            EdgeDelta("state", "kernel", lag_cycles=2048, value_id="large"),
+        ],
+    )
+
+    contract = derive_temporal_execution_contract(process)
+    storage = {mapping.component_id: mapping for mapping in contract.edge_delta_storage}
+
+    assert storage["kernel->state@128:medium"].storage_kind == TemporalStorageKind.FIFO
+    assert storage["state->kernel@2048:large"].storage_kind == TemporalStorageKind.RAM
+
+
 def test_contract_maps_buffer_depth_to_storage_kind() -> None:
     process = Process(
         process_id="buffer_storage",

--- a/tests/unit/test_temporal_hls.py
+++ b/tests/unit/test_temporal_hls.py
@@ -4,6 +4,7 @@ from tempo_dag.codegen.hls.temporal_generator import (
     render_temporal_artifact_from_trace,
     render_temporal_process_hls,
 )
+from tempo_dag.examples import rolling_window_process
 from tempo_dag.parsers.temporal_onnx import (
     TemporalONNXParser,
     build_demo_temporal_onnx_model,
@@ -63,3 +64,14 @@ def test_render_temporal_process_hls_includes_half_header_for_float16_buffers() 
 
     assert "#include <hls_half.h>" in rendered
     assert "static half" in rendered
+
+
+def test_render_temporal_process_hls_includes_execution_contract_comments() -> None:
+    rendered = render_temporal_process_hls(rolling_window_process())
+
+    assert "// reset_policy: zero" in rendered
+    assert "// warmup_timesteps: 7" in rendered
+    assert "// flush_cycles: 0" in rendered
+    assert "// edge_delta_storage: feature_kernel->rolling_window@1:x" in rendered
+    assert "-> register latency=1" in rendered
+    assert "// buffer_storage: rolling_window -> ring_buffer latency=8" in rendered


### PR DESCRIPTION
## Summary

- Adds a dedicated temporal execution and HLS lowering contract document
- Adds a machine-readable temporal execution contract helper for reset, warm-up, flush, and storage mapping
- Adds canonical M1 reference processes for delay, recurrence, rolling windows, and initialized state reset
- Annotates generated temporal HLS with derived contract comments

## Commit structure

- docs: define temporal execution contract
- feat: derive temporal execution contract
- test: add temporal reference processes
- feat: annotate temporal HLS contract

## Validation

- python -m ruff check src tests
- python -m pytest -q