### PR TITLE
Implement generated HLS artifact baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,5 +194,8 @@ jobs:
           .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install -r requirements.txt
 
+      - name: Install C++ compiler for generated HLS smoke tests
+        run: sudo apt-get update && sudo apt-get install -y g++
+
       - name: Run test suite
         run: PYTHONPATH=src .venv/bin/python -m pytest -q

--- a/docs/temporal-quickstart.md
+++ b/docs/temporal-quickstart.md
@@ -6,6 +6,8 @@ This guide walks through the Week 4 MVP path in TempoDAG:
 2. Lower it into `tempo_dag.ir_temporal.Process`.
 3. Generate a golden trace from a timestep-by-timestep PyTorch reference.
 4. Emit temporal HLS C++ plus a simple testbench.
+5. Write a graph-level artifact bundle with a manifest tying the process,
+   golden trace, generated HLS, and testbench together.
 
 ## Supported MVP Path
 
@@ -36,7 +38,13 @@ The demo writes artifacts to `examples/generated/`:
 - `temporal_demo_trace.json`
 - `temporal_demo.cpp`
 - `temporal_demo_tb.cpp`
+- `temporal_demo_manifest.json`
 - `temporal_demo_report.json`
+
+The manifest is the stable entry point for generated artifacts. It lists the
+temporal process JSON, golden trace, generated process HLS, and generated
+testbench for the same pipeline so downstream notebooks, reports, and future
+HLS scripts do not need to rediscover file names.
 
 ## API Reference
 
@@ -44,6 +52,7 @@ Key Week 4 entry points:
 
 - `tempo_dag.parsers.temporal_onnx.TemporalONNXParser`
 - `tempo_dag.parsers.temporal_onnx.build_demo_temporal_onnx_model`
+- `tempo_dag.codegen.hls.temporal_generator.write_temporal_hls_artifact_bundle`
 - `tempo_dag.codegen.hls.temporal_generator.render_temporal_process_hls`
 - `tempo_dag.codegen.hls.temporal_generator.render_temporal_testbench`
 - `tempo_dag.verification.temporal_parity.StreamingPyTorchAdapter`
@@ -61,11 +70,14 @@ The verification ladder for the MVP is:
 
 ## HLS Walkthrough
 
-The temporal HLS generator produces two artifacts:
+The temporal HLS bundle writer produces a graph-level artifact package:
 
-- a top-level process wrapper with buffer declarations and rendered operator
-  kernels
-- a testbench that replays each timestep from a golden trace
+- a temporal process JSON file
+- a golden trace JSON file
+- a top-level process wrapper with buffer declarations, contract comments, and
+  rendered operator kernels
+- a testbench that replays each timestep from the golden trace
+- a manifest that records the artifact paths and process identifier
 
 The generated C++ is intentionally transparent and inspection-friendly. It is
 meant to prove the process/codegen interface and testbench wiring before the
@@ -80,5 +92,6 @@ ONNX model
   -> StreamingPyTorchAdapter
   -> FixedPointOracle
   -> GoldenTraceRecorder
-  -> render_temporal_process_hls + render_temporal_testbench
+  -> write_temporal_hls_artifact_bundle
+  -> process JSON + golden trace + HLS + testbench + manifest
 ```

--- a/docs/temporal-quickstart.md
+++ b/docs/temporal-quickstart.md
@@ -83,6 +83,46 @@ The generated C++ is intentionally transparent and inspection-friendly. It is
 meant to prove the process/codegen interface and testbench wiring before the
 project grows a richer temporal scheduler.
 
+## HLS Milestone 2 Compile Contract
+
+The current HLS layer is no longer only a text renderer. Unit tests now render
+representative operator templates into real C++ translation units and compile
+them with a standard C++17 compiler using `-fsyntax-only`. This gives the
+project a fast CI check that catches broken template syntax without requiring a
+Vitis or Vivado installation.
+
+The compile-smoke contract currently covers:
+
+- scalar/tensor elementwise kernels: `Add`, `Sub`, `Mul`, `Div`, `Sigmoid`,
+  `Tanh`, `ReLU`, and `GELU`
+- reductions: `Sum`, `Mean`, and `Max`
+- structural kernels: `MatMul`, `Transpose`, `Reshape`, `Concat`, `Slice`,
+  `Pad`, and `Shift`
+- temporal/model kernels: `Softmax`, `LayerNorm`, `Conv1D`, `LSTM`, and the
+  generated temporal process/testbench pair
+
+This is still a baseline HLS ABI, not the final optimized accelerator ABI. The
+templates are written to be readable, pragma-ready, and compiler-checkable so
+the next scheduler layer has a stable target.
+
+## Supported HLS Subset
+
+The Python IR validates a broader graph vocabulary than the first HLS template
+set can lower. The current compiler-checked HLS subset intentionally supports:
+
+- `float32` operator examples in the compile-smoke suite
+- rank-2 matrix `MatMul`
+- rank-2 `Transpose` with `perm=[1, 0]`
+- rank-1 `Slice`, `Pad`, and `Shift`
+- flattened reductions where the reduced dimension is contiguous in the
+  generated layout
+- `Conv1D` in `[batch, channel, time]` layout with static shapes
+- `LSTM` with `X`, `W`, `R`, optional `B`, and the primary `Y` output
+
+Unsupported HLS forms raise explicit render-time errors rather than emitting
+misleading C++. The next graph scheduler should replace those narrow cases with
+shape-aware address generation and a consistent operator invocation ABI.
+
 ## Sequence Overview
 
 ```text

--- a/hls/operators/add.cpp.tpl
+++ b/hls/operators/add.cpp.tpl
@@ -2,7 +2,22 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} lhs[${input_0_size}],
+    const ${cpp_dtype} rhs[${input_1_size}],
+    ${cpp_dtype} out[${output_0_size}]
+) {
+  static constexpr int kOutputSize = ${output_0_size};
+  static constexpr bool kScalarLhs = ${has_scalar_lhs};
+  static constexpr bool kScalarRhs = ${has_scalar_rhs};
+
+add_loop:
+  for (int idx = 0; idx < kOutputSize; ++idx) {
+#pragma HLS PIPELINE II=1
+    const ${cpp_dtype} lhs_value = kScalarLhs ? lhs[0] : lhs[idx];
+    const ${cpp_dtype} rhs_value = kScalarRhs ? rhs[0] : rhs[idx];
+    out[idx] = lhs_value + rhs_value;
+  }
+}

--- a/hls/operators/concat.cpp.tpl
+++ b/hls/operators/concat.cpp.tpl
@@ -2,7 +2,23 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype}* const inputs[${num_inputs}],
+    ${cpp_dtype} out[${output_size}]
+) {
+  static constexpr int kNumInputs = ${num_inputs};
+  const int input_sizes[kNumInputs] = {${input_sizes_csv}};
+  int out_offset = 0;
+
+concat_input_loop:
+  for (int input_idx = 0; input_idx < kNumInputs; ++input_idx) {
+concat_copy_loop:
+    for (int elem = 0; elem < input_sizes[input_idx]; ++elem) {
+#pragma HLS PIPELINE II=1
+      out[out_offset + elem] = inputs[input_idx][elem];
+    }
+    out_offset += input_sizes[input_idx];
+  }
+}

--- a/hls/operators/conv1_d.cpp.tpl
+++ b/hls/operators/conv1_d.cpp.tpl
@@ -6,8 +6,7 @@
 // Output shapes: ${output_shapes}
 void ${op_id}_kernel(
     const ${cpp_dtype} input[${batch}][${in_channels}][${input_length}],
-    const ${cpp_dtype} weight[${out_channels}][${in_channels}][${kernel_width}],
-    const ${cpp_dtype} bias[${out_channels}],
+    const ${cpp_dtype} weight[${out_channels}][${in_channels}][${kernel_width}]${bias_parameter},
     ${cpp_dtype} out[${batch}][${out_channels}][${output_length}]
 ) {
 conv_batch_loop:
@@ -17,7 +16,7 @@ conv_out_channel_loop:
 conv_time_loop:
       for (int out_t = 0; out_t < ${output_length}; ++out_t) {
 #pragma HLS PIPELINE II=1
-        ${cpp_dtype} acc = ${has_bias} ? bias[out_channel] : (${cpp_dtype})0;
+        ${cpp_dtype} acc = ${bias_init};
 conv_in_channel_loop:
         for (int in_channel = 0; in_channel < ${in_channels}; ++in_channel) {
 conv_kernel_loop:

--- a/hls/operators/conv1_d.cpp.tpl
+++ b/hls/operators/conv1_d.cpp.tpl
@@ -2,7 +2,36 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${batch}][${in_channels}][${input_length}],
+    const ${cpp_dtype} weight[${out_channels}][${in_channels}][${kernel_width}],
+    const ${cpp_dtype} bias[${out_channels}],
+    ${cpp_dtype} out[${batch}][${out_channels}][${output_length}]
+) {
+conv_batch_loop:
+  for (int batch = 0; batch < ${batch}; ++batch) {
+conv_out_channel_loop:
+    for (int out_channel = 0; out_channel < ${out_channels}; ++out_channel) {
+conv_time_loop:
+      for (int out_t = 0; out_t < ${output_length}; ++out_t) {
+#pragma HLS PIPELINE II=1
+        ${cpp_dtype} acc = ${has_bias} ? bias[out_channel] : (${cpp_dtype})0;
+conv_in_channel_loop:
+        for (int in_channel = 0; in_channel < ${in_channels}; ++in_channel) {
+conv_kernel_loop:
+          for (int kernel = 0; kernel < ${kernel_width}; ++kernel) {
+#pragma HLS UNROLL factor=2
+            const int in_t = out_t * ${stride} + kernel * ${dilation} - ${padding};
+            if (in_t >= 0 && in_t < ${input_length}) {
+              acc += input[batch][in_channel][in_t] *
+                     weight[out_channel][in_channel][kernel];
+            }
+          }
+        }
+        out[batch][out_channel][out_t] = acc;
+      }
+    }
+  }
+}

--- a/hls/operators/delay.cpp.tpl
+++ b/hls/operators/delay.cpp.tpl
@@ -1,5 +1,16 @@
 // Operator: $op_type
 // Kernel: ${op_id}_kernel
-// Delay lag_cycles: ${attrs}
+// Delay attrs: ${attrs}
 // Inputs: $inputs
 // Outputs: $outputs
+template <typename T, int Depth>
+void ${op_id}_kernel(const T input, T& output, T state[Depth]) {
+#pragma HLS INLINE
+  output = state[0];
+delay_shift_loop:
+  for (int idx = 0; idx < Depth - 1; ++idx) {
+#pragma HLS PIPELINE II=1
+    state[idx] = state[idx + 1];
+  }
+  state[Depth - 1] = input;
+}

--- a/hls/operators/div.cpp.tpl
+++ b/hls/operators/div.cpp.tpl
@@ -2,7 +2,22 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} lhs[${input_0_size}],
+    const ${cpp_dtype} rhs[${input_1_size}],
+    ${cpp_dtype} out[${output_0_size}]
+) {
+  static constexpr int kOutputSize = ${output_0_size};
+  static constexpr bool kScalarLhs = ${has_scalar_lhs};
+  static constexpr bool kScalarRhs = ${has_scalar_rhs};
+
+div_loop:
+  for (int idx = 0; idx < kOutputSize; ++idx) {
+#pragma HLS PIPELINE II=1
+    const ${cpp_dtype} lhs_value = kScalarLhs ? lhs[0] : lhs[idx];
+    const ${cpp_dtype} rhs_value = kScalarRhs ? rhs[0] : rhs[idx];
+    out[idx] = lhs_value / rhs_value;
+  }
+}

--- a/hls/operators/g_e_l_u.cpp.tpl
+++ b/hls/operators/g_e_l_u.cpp.tpl
@@ -1,8 +1,23 @@
+#include <cmath>
+
 // Operator: GELU
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${input_0_size}],
+    ${cpp_dtype} out[${output_0_size}]
+) {
+  static constexpr ${cpp_dtype} kAlpha = (${cpp_dtype})0.7978845608028654;
+  static constexpr ${cpp_dtype} kBeta = (${cpp_dtype})0.044715;
+
+gelu_loop:
+  for (int idx = 0; idx < ${output_0_size}; ++idx) {
+#pragma HLS PIPELINE II=1
+    const ${cpp_dtype} x = input[idx];
+    const ${cpp_dtype} inner = kAlpha * (x + kBeta * x * x * x);
+    out[idx] = (${cpp_dtype})0.5 * x * ((${cpp_dtype})1 + std::tanh(inner));
+  }
+}

--- a/hls/operators/l_s_t_m.cpp.tpl
+++ b/hls/operators/l_s_t_m.cpp.tpl
@@ -9,8 +9,7 @@
 void ${op_id}_kernel(
     const ${cpp_dtype} x[${seq_len}][${batch}][${input_size}],
     const ${cpp_dtype} w[${num_directions}][${hidden_size} * 4][${input_size}],
-    const ${cpp_dtype} r[${num_directions}][${hidden_size} * 4][${hidden_size}],
-    const ${cpp_dtype} b[${num_directions}][${hidden_size} * 8],
+    const ${cpp_dtype} r[${num_directions}][${hidden_size} * 4][${hidden_size}]${bias_parameter},
     ${cpp_dtype} y[${seq_len}][${num_directions}][${batch}][${hidden_size}]
 ) {
 lstm_direction_loop:
@@ -37,21 +36,10 @@ lstm_time_loop:
 lstm_hidden_loop:
         for (int hidden_idx = 0; hidden_idx < ${hidden_size}; ++hidden_idx) {
 #pragma HLS PIPELINE II=1
-          ${cpp_dtype} gate_i = ${has_bias}
-              ? b[direction][hidden_idx] + b[direction][4 * ${hidden_size} + hidden_idx]
-              : (${cpp_dtype})0;
-          ${cpp_dtype} gate_o = ${has_bias}
-              ? b[direction][${hidden_size} + hidden_idx] +
-                    b[direction][5 * ${hidden_size} + hidden_idx]
-              : (${cpp_dtype})0;
-          ${cpp_dtype} gate_f = ${has_bias}
-              ? b[direction][2 * ${hidden_size} + hidden_idx] +
-                    b[direction][6 * ${hidden_size} + hidden_idx]
-              : (${cpp_dtype})0;
-          ${cpp_dtype} gate_c = ${has_bias}
-              ? b[direction][3 * ${hidden_size} + hidden_idx] +
-                    b[direction][7 * ${hidden_size} + hidden_idx]
-              : (${cpp_dtype})0;
+          ${cpp_dtype} gate_i = ${gate_i_bias};
+          ${cpp_dtype} gate_o = ${gate_o_bias};
+          ${cpp_dtype} gate_f = ${gate_f_bias};
+          ${cpp_dtype} gate_c = ${gate_c_bias};
 
 lstm_input_loop:
           for (int input_idx = 0; input_idx < ${input_size}; ++input_idx) {

--- a/hls/operators/l_s_t_m.cpp.tpl
+++ b/hls/operators/l_s_t_m.cpp.tpl
@@ -1,0 +1,98 @@
+#include <cmath>
+
+// Operator: LSTM
+// Kernel: ${op_id}_kernel
+// Inputs: ${inputs}
+// Outputs: ${outputs}
+// Input shapes: ${input_shapes}
+// Output shapes: ${output_shapes}
+void ${op_id}_kernel(
+    const ${cpp_dtype} x[${seq_len}][${batch}][${input_size}],
+    const ${cpp_dtype} w[${num_directions}][${hidden_size} * 4][${input_size}],
+    const ${cpp_dtype} r[${num_directions}][${hidden_size} * 4][${hidden_size}],
+    const ${cpp_dtype} b[${num_directions}][${hidden_size} * 8],
+    ${cpp_dtype} y[${seq_len}][${num_directions}][${batch}][${hidden_size}]
+) {
+lstm_direction_loop:
+  for (int direction = 0; direction < ${num_directions}; ++direction) {
+lstm_batch_loop:
+    for (int batch = 0; batch < ${batch}; ++batch) {
+      ${cpp_dtype} hidden[${hidden_size}];
+      ${cpp_dtype} cell[${hidden_size}];
+#pragma HLS ARRAY_PARTITION variable=hidden cyclic factor=4
+#pragma HLS ARRAY_PARTITION variable=cell cyclic factor=4
+
+lstm_state_init_loop:
+      for (int hidden_idx = 0; hidden_idx < ${hidden_size}; ++hidden_idx) {
+#pragma HLS PIPELINE II=1
+        hidden[hidden_idx] = (${cpp_dtype})0;
+        cell[hidden_idx] = (${cpp_dtype})0;
+      }
+
+lstm_time_loop:
+      for (int step = 0; step < ${seq_len}; ++step) {
+        const bool reverse = ${reverse_direction} || (${num_directions} == 2 && direction == 1);
+        const int time_idx = reverse ? (${seq_len} - 1 - step) : step;
+
+lstm_hidden_loop:
+        for (int hidden_idx = 0; hidden_idx < ${hidden_size}; ++hidden_idx) {
+#pragma HLS PIPELINE II=1
+          ${cpp_dtype} gate_i = ${has_bias}
+              ? b[direction][hidden_idx] + b[direction][4 * ${hidden_size} + hidden_idx]
+              : (${cpp_dtype})0;
+          ${cpp_dtype} gate_o = ${has_bias}
+              ? b[direction][${hidden_size} + hidden_idx] +
+                    b[direction][5 * ${hidden_size} + hidden_idx]
+              : (${cpp_dtype})0;
+          ${cpp_dtype} gate_f = ${has_bias}
+              ? b[direction][2 * ${hidden_size} + hidden_idx] +
+                    b[direction][6 * ${hidden_size} + hidden_idx]
+              : (${cpp_dtype})0;
+          ${cpp_dtype} gate_c = ${has_bias}
+              ? b[direction][3 * ${hidden_size} + hidden_idx] +
+                    b[direction][7 * ${hidden_size} + hidden_idx]
+              : (${cpp_dtype})0;
+
+lstm_input_loop:
+          for (int input_idx = 0; input_idx < ${input_size}; ++input_idx) {
+#pragma HLS UNROLL factor=2
+            const ${cpp_dtype} input_value = x[time_idx][batch][input_idx];
+            gate_i += input_value * w[direction][hidden_idx][input_idx];
+            gate_o +=
+                input_value * w[direction][${hidden_size} + hidden_idx][input_idx];
+            gate_f += input_value *
+                      w[direction][2 * ${hidden_size} + hidden_idx][input_idx];
+            gate_c += input_value *
+                      w[direction][3 * ${hidden_size} + hidden_idx][input_idx];
+          }
+
+lstm_recurrent_loop:
+          for (int recurrent_idx = 0; recurrent_idx < ${hidden_size};
+               ++recurrent_idx) {
+#pragma HLS UNROLL factor=2
+            const ${cpp_dtype} recurrent_value = hidden[recurrent_idx];
+            gate_i += recurrent_value * r[direction][hidden_idx][recurrent_idx];
+            gate_o += recurrent_value *
+                      r[direction][${hidden_size} + hidden_idx][recurrent_idx];
+            gate_f += recurrent_value *
+                      r[direction][2 * ${hidden_size} + hidden_idx][recurrent_idx];
+            gate_c += recurrent_value *
+                      r[direction][3 * ${hidden_size} + hidden_idx][recurrent_idx];
+          }
+
+          const ${cpp_dtype} input_gate =
+              (${cpp_dtype})1 / ((${cpp_dtype})1 + std::exp(-gate_i));
+          const ${cpp_dtype} output_gate =
+              (${cpp_dtype})1 / ((${cpp_dtype})1 + std::exp(-gate_o));
+          const ${cpp_dtype} forget_gate =
+              (${cpp_dtype})1 / ((${cpp_dtype})1 + std::exp(-gate_f));
+          const ${cpp_dtype} candidate = std::tanh(gate_c);
+
+          cell[hidden_idx] = forget_gate * cell[hidden_idx] + input_gate * candidate;
+          hidden[hidden_idx] = output_gate * std::tanh(cell[hidden_idx]);
+          y[time_idx][direction][batch][hidden_idx] = hidden[hidden_idx];
+        }
+      }
+    }
+  }
+}

--- a/hls/operators/layer_norm.cpp.tpl
+++ b/hls/operators/layer_norm.cpp.tpl
@@ -1,8 +1,40 @@
+#include <cmath>
+
 // Operator: LayerNorm
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${output_0_size}],
+    ${cpp_dtype} out[${output_0_size}]
+) {
+layer_norm_outer_loop:
+  for (int outer = 0; outer < ${outer_size}; ++outer) {
+    ${cpp_dtype} mean = (${cpp_dtype})0;
+layer_norm_mean_loop:
+    for (int idx = 0; idx < ${normalized_size}; ++idx) {
+#pragma HLS PIPELINE II=1
+      mean += input[outer * ${normalized_size} + idx];
+    }
+    mean /= (${cpp_dtype})${normalized_size};
+
+    ${cpp_dtype} variance = (${cpp_dtype})0;
+layer_norm_var_loop:
+    for (int idx = 0; idx < ${normalized_size}; ++idx) {
+#pragma HLS PIPELINE II=1
+      const ${cpp_dtype} centered = input[outer * ${normalized_size} + idx] - mean;
+      variance += centered * centered;
+    }
+    variance /= (${cpp_dtype})${normalized_size};
+    const ${cpp_dtype} inv_std = (${cpp_dtype})1 / std::sqrt(variance + (${cpp_dtype})${epsilon});
+
+layer_norm_write_loop:
+    for (int idx = 0; idx < ${normalized_size}; ++idx) {
+#pragma HLS PIPELINE II=1
+      out[outer * ${normalized_size} + idx] =
+          (input[outer * ${normalized_size} + idx] - mean) * inv_std;
+    }
+  }
+}

--- a/hls/operators/mat_mul.cpp.tpl
+++ b/hls/operators/mat_mul.cpp.tpl
@@ -2,7 +2,25 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} lhs[${m_dim}][${k_dim}],
+    const ${cpp_dtype} rhs[${k_dim}][${n_dim}],
+    ${cpp_dtype} out[${m_dim}][${n_dim}]
+) {
+matmul_row_loop:
+  for (int row = 0; row < ${m_dim}; ++row) {
+matmul_col_loop:
+    for (int col = 0; col < ${n_dim}; ++col) {
+#pragma HLS PIPELINE II=1
+      ${cpp_dtype} acc = (${cpp_dtype})0;
+matmul_reduce_loop:
+      for (int k = 0; k < ${k_dim}; ++k) {
+#pragma HLS UNROLL factor=4
+        acc += lhs[row][k] * rhs[k][col];
+      }
+      out[row][col] = acc;
+    }
+  }
+}

--- a/hls/operators/max.cpp.tpl
+++ b/hls/operators/max.cpp.tpl
@@ -2,7 +2,21 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${input_size}],
+    ${cpp_dtype} out[${output_size}]
+) {
+max_output_loop:
+  for (int out_idx = 0; out_idx < ${output_size}; ++out_idx) {
+    ${cpp_dtype} current = input[out_idx * ${reduction_size}];
+max_reduce_loop:
+    for (int red_idx = 1; red_idx < ${reduction_size}; ++red_idx) {
+#pragma HLS PIPELINE II=1
+      const ${cpp_dtype} value = input[out_idx * ${reduction_size} + red_idx];
+      current = value > current ? value : current;
+    }
+    out[out_idx] = current;
+  }
+}

--- a/hls/operators/mean.cpp.tpl
+++ b/hls/operators/mean.cpp.tpl
@@ -2,7 +2,20 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${input_size}],
+    ${cpp_dtype} out[${output_size}]
+) {
+mean_output_loop:
+  for (int out_idx = 0; out_idx < ${output_size}; ++out_idx) {
+    ${cpp_dtype} acc = (${cpp_dtype})0;
+mean_reduce_loop:
+    for (int red_idx = 0; red_idx < ${reduction_size}; ++red_idx) {
+#pragma HLS PIPELINE II=1
+      acc += input[out_idx * ${reduction_size} + red_idx];
+    }
+    out[out_idx] = acc / (${cpp_dtype})${reduction_size};
+  }
+}

--- a/hls/operators/mul.cpp.tpl
+++ b/hls/operators/mul.cpp.tpl
@@ -2,7 +2,22 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} lhs[${input_0_size}],
+    const ${cpp_dtype} rhs[${input_1_size}],
+    ${cpp_dtype} out[${output_0_size}]
+) {
+  static constexpr int kOutputSize = ${output_0_size};
+  static constexpr bool kScalarLhs = ${has_scalar_lhs};
+  static constexpr bool kScalarRhs = ${has_scalar_rhs};
+
+mul_loop:
+  for (int idx = 0; idx < kOutputSize; ++idx) {
+#pragma HLS PIPELINE II=1
+    const ${cpp_dtype} lhs_value = kScalarLhs ? lhs[0] : lhs[idx];
+    const ${cpp_dtype} rhs_value = kScalarRhs ? rhs[0] : rhs[idx];
+    out[idx] = lhs_value * rhs_value;
+  }
+}

--- a/hls/operators/pad.cpp.tpl
+++ b/hls/operators/pad.cpp.tpl
@@ -2,7 +2,19 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${input_size}],
+    ${cpp_dtype} out[${output_size}]
+) {
+pad_loop:
+  for (int idx = 0; idx < ${output_size}; ++idx) {
+#pragma HLS PIPELINE II=1
+    if (idx < ${pad_before} || idx >= ${pad_before} + ${input_size}) {
+      out[idx] = (${cpp_dtype})0;
+    } else {
+      out[idx] = input[idx - ${pad_before}];
+    }
+  }
+}

--- a/hls/operators/re_l_u.cpp.tpl
+++ b/hls/operators/re_l_u.cpp.tpl
@@ -2,7 +2,16 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${input_0_size}],
+    ${cpp_dtype} out[${output_0_size}]
+) {
+relu_loop:
+  for (int idx = 0; idx < ${output_0_size}; ++idx) {
+#pragma HLS PIPELINE II=1
+    const ${cpp_dtype} value = input[idx];
+    out[idx] = value > (${cpp_dtype})0 ? value : (${cpp_dtype})0;
+  }
+}

--- a/hls/operators/reshape.cpp.tpl
+++ b/hls/operators/reshape.cpp.tpl
@@ -2,7 +2,15 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${num_elements}],
+    ${cpp_dtype} out[${num_elements}]
+) {
+reshape_copy_loop:
+  for (int idx = 0; idx < ${num_elements}; ++idx) {
+#pragma HLS PIPELINE II=1
+    out[idx] = input[idx];
+  }
+}

--- a/hls/operators/rolling_mean.cpp.tpl
+++ b/hls/operators/rolling_mean.cpp.tpl
@@ -3,3 +3,23 @@
 // RollingMean attrs: ${attrs}
 // Inputs: $inputs
 // Outputs: $outputs
+template <typename T, int Window>
+void ${op_id}_kernel(const T input, T window[Window], T& mean) {
+#pragma HLS INLINE
+  T dropped = window[0];
+rolling_mean_shift_loop:
+  for (int idx = 0; idx < Window - 1; ++idx) {
+#pragma HLS PIPELINE II=1
+    window[idx] = window[idx + 1];
+  }
+  window[Window - 1] = input;
+
+  T sum = (T)0;
+rolling_mean_sum_loop:
+  for (int idx = 0; idx < Window; ++idx) {
+#pragma HLS PIPELINE II=1
+    sum += window[idx];
+  }
+  (void)dropped;
+  mean = sum / (T)Window;
+}

--- a/hls/operators/rolling_var.cpp.tpl
+++ b/hls/operators/rolling_var.cpp.tpl
@@ -3,3 +3,30 @@
 // RollingVar attrs: ${attrs}
 // Inputs: $inputs
 // Outputs: $outputs
+template <typename T, int Window>
+void ${op_id}_kernel(const T input, T window[Window], T& variance) {
+#pragma HLS INLINE
+rolling_var_shift_loop:
+  for (int idx = 0; idx < Window - 1; ++idx) {
+#pragma HLS PIPELINE II=1
+    window[idx] = window[idx + 1];
+  }
+  window[Window - 1] = input;
+
+  T mean = (T)0;
+rolling_var_mean_loop:
+  for (int idx = 0; idx < Window; ++idx) {
+#pragma HLS PIPELINE II=1
+    mean += window[idx];
+  }
+  mean /= (T)Window;
+
+  T accum = (T)0;
+rolling_var_accum_loop:
+  for (int idx = 0; idx < Window; ++idx) {
+#pragma HLS PIPELINE II=1
+    const T centered = window[idx] - mean;
+    accum += centered * centered;
+  }
+  variance = accum / (T)Window;
+}

--- a/hls/operators/rolling_window.cpp.tpl
+++ b/hls/operators/rolling_window.cpp.tpl
@@ -3,3 +3,13 @@
 // RollingWindow attrs: ${attrs}
 // Inputs: $inputs
 // Outputs: $outputs
+template <typename T, int Window>
+void ${op_id}_kernel(const T input, T window[Window]) {
+#pragma HLS INLINE
+rolling_window_shift_loop:
+  for (int idx = 0; idx < Window - 1; ++idx) {
+#pragma HLS PIPELINE II=1
+    window[idx] = window[idx + 1];
+  }
+  window[Window - 1] = input;
+}

--- a/hls/operators/shift.cpp.tpl
+++ b/hls/operators/shift.cpp.tpl
@@ -2,7 +2,18 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${output_size}],
+    ${cpp_dtype} out[${output_size}]
+) {
+shift_loop:
+  for (int idx = 0; idx < ${output_size}; ++idx) {
+#pragma HLS PIPELINE II=1
+    const int source = idx - (${amount});
+    out[idx] = (source >= 0 && source < ${output_size})
+        ? input[source]
+        : (${cpp_dtype})0;
+  }
+}

--- a/hls/operators/sigmoid.cpp.tpl
+++ b/hls/operators/sigmoid.cpp.tpl
@@ -1,8 +1,18 @@
+#include <cmath>
+
 // Operator: Sigmoid
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${input_0_size}],
+    ${cpp_dtype} out[${output_0_size}]
+) {
+sigmoid_loop:
+  for (int idx = 0; idx < ${output_0_size}; ++idx) {
+#pragma HLS PIPELINE II=1
+    out[idx] = (${cpp_dtype})1 / ((${cpp_dtype})1 + std::exp(-input[idx]));
+  }
+}

--- a/hls/operators/slice.cpp.tpl
+++ b/hls/operators/slice.cpp.tpl
@@ -2,7 +2,15 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${input_0_size}],
+    ${cpp_dtype} out[${output_size}]
+) {
+slice_loop:
+  for (int idx = 0; idx < ${output_size}; ++idx) {
+#pragma HLS PIPELINE II=1
+    out[idx] = input[${start} + idx * ${step}];
+  }
+}

--- a/hls/operators/softmax.cpp.tpl
+++ b/hls/operators/softmax.cpp.tpl
@@ -1,8 +1,43 @@
+#include <cmath>
+
 // Operator: Softmax
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${output_0_size}],
+    ${cpp_dtype} out[${output_0_size}]
+) {
+softmax_outer_loop:
+  for (int outer = 0; outer < ${outer_size}; ++outer) {
+softmax_inner_loop:
+    for (int inner = 0; inner < ${inner_size}; ++inner) {
+      ${cpp_dtype} max_value = input[outer * ${axis_size} * ${inner_size} + inner];
+softmax_max_loop:
+      for (int axis = 1; axis < ${axis_size}; ++axis) {
+#pragma HLS PIPELINE II=1
+        const int idx = outer * ${axis_size} * ${inner_size} + axis * ${inner_size} + inner;
+        max_value = input[idx] > max_value ? input[idx] : max_value;
+      }
+
+      ${cpp_dtype} denom = (${cpp_dtype})0;
+softmax_exp_loop:
+      for (int axis = 0; axis < ${axis_size}; ++axis) {
+#pragma HLS PIPELINE II=1
+        const int idx = outer * ${axis_size} * ${inner_size} + axis * ${inner_size} + inner;
+        const ${cpp_dtype} value = std::exp(input[idx] - max_value);
+        out[idx] = value;
+        denom += value;
+      }
+
+softmax_norm_loop:
+      for (int axis = 0; axis < ${axis_size}; ++axis) {
+#pragma HLS PIPELINE II=1
+        const int idx = outer * ${axis_size} * ${inner_size} + axis * ${inner_size} + inner;
+        out[idx] = out[idx] / denom;
+      }
+    }
+  }
+}

--- a/hls/operators/sub.cpp.tpl
+++ b/hls/operators/sub.cpp.tpl
@@ -2,7 +2,22 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} lhs[${input_0_size}],
+    const ${cpp_dtype} rhs[${input_1_size}],
+    ${cpp_dtype} out[${output_0_size}]
+) {
+  static constexpr int kOutputSize = ${output_0_size};
+  static constexpr bool kScalarLhs = ${has_scalar_lhs};
+  static constexpr bool kScalarRhs = ${has_scalar_rhs};
+
+sub_loop:
+  for (int idx = 0; idx < kOutputSize; ++idx) {
+#pragma HLS PIPELINE II=1
+    const ${cpp_dtype} lhs_value = kScalarLhs ? lhs[0] : lhs[idx];
+    const ${cpp_dtype} rhs_value = kScalarRhs ? rhs[0] : rhs[idx];
+    out[idx] = lhs_value - rhs_value;
+  }
+}

--- a/hls/operators/sum.cpp.tpl
+++ b/hls/operators/sum.cpp.tpl
@@ -2,7 +2,20 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${input_size}],
+    ${cpp_dtype} out[${output_size}]
+) {
+sum_output_loop:
+  for (int out_idx = 0; out_idx < ${output_size}; ++out_idx) {
+    ${cpp_dtype} acc = (${cpp_dtype})0;
+sum_reduce_loop:
+    for (int red_idx = 0; red_idx < ${reduction_size}; ++red_idx) {
+#pragma HLS PIPELINE II=1
+      acc += input[out_idx * ${reduction_size} + red_idx];
+    }
+    out[out_idx] = acc;
+  }
+}

--- a/hls/operators/tanh.cpp.tpl
+++ b/hls/operators/tanh.cpp.tpl
@@ -1,8 +1,18 @@
+#include <cmath>
+
 // Operator: Tanh
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${input_0_size}],
+    ${cpp_dtype} out[${output_0_size}]
+) {
+tanh_loop:
+  for (int idx = 0; idx < ${output_0_size}; ++idx) {
+#pragma HLS PIPELINE II=1
+    out[idx] = std::tanh(input[idx]);
+  }
+}

--- a/hls/operators/transpose.cpp.tpl
+++ b/hls/operators/transpose.cpp.tpl
@@ -2,7 +2,18 @@
 // Kernel: ${op_id}_kernel
 // Inputs: ${inputs}
 // Outputs: ${outputs}
-// Attributes: ${attrs}
 // Input shapes: ${input_shapes}
 // Output shapes: ${output_shapes}
-void ${op_id}_kernel() {}
+void ${op_id}_kernel(
+    const ${cpp_dtype} input[${rows}][${cols}],
+    ${cpp_dtype} out[${cols}][${rows}]
+) {
+transpose_row_loop:
+  for (int row = 0; row < ${rows}; ++row) {
+transpose_col_loop:
+    for (int col = 0; col < ${cols}; ++col) {
+#pragma HLS PIPELINE II=1
+      out[col][row] = input[row][col];
+    }
+  }
+}

--- a/src/tempo_dag/codegen/hls/temporal_generator.py
+++ b/src/tempo_dag/codegen/hls/temporal_generator.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from enum import Enum
 from os import PathLike
 from pathlib import Path
 
@@ -13,12 +15,50 @@ from tempo_dag.ir_temporal import (
 from tempo_dag.verification.golden_trace import GoldenTrace, load_golden_trace
 
 
+class TemporalArtifactKind(Enum):
+    """Known graph-level temporal artifact categories."""
+
+    PROCESS_JSON = "process_json"
+    GOLDEN_TRACE_JSON = "golden_trace_json"
+    PROCESS_HLS = "process_hls"
+    TESTBENCH_HLS = "testbench_hls"
+    MANIFEST_JSON = "manifest_json"
+
+
+@dataclass(frozen=True)
+class TemporalArtifactFile:
+    """One file emitted for a graph-level temporal HLS bundle."""
+
+    kind: TemporalArtifactKind
+    path: Path
+
+    def to_dict(self, root: Path) -> dict[str, str]:
+        return {
+            "kind": self.kind.value,
+            "path": self.path.relative_to(root).as_posix(),
+        }
+
+
 @dataclass(frozen=True)
 class TemporalHLSArtifact:
     """Rendered temporal HLS bundle for a Process."""
 
     process_hls: str
     testbench_hls: str
+
+
+@dataclass(frozen=True)
+class TemporalHLSArtifactManifest:
+    """Manifest for a graph-level temporal HLS artifact bundle."""
+
+    process_id: str
+    files: tuple[TemporalArtifactFile, ...]
+
+    def to_dict(self, root: Path) -> dict[str, object]:
+        return {
+            "process_id": self.process_id,
+            "files": [artifact.to_dict(root) for artifact in self.files],
+        }
 
 
 def render_temporal_process_hls(process: Process) -> str:
@@ -150,6 +190,54 @@ def render_temporal_artifact_from_trace(
     )
 
 
+def write_temporal_hls_artifact_bundle(
+    process: Process,
+    golden_trace: GoldenTrace,
+    output_dir: str | PathLike[str],
+    *,
+    stem: str | None = None,
+) -> TemporalHLSArtifactManifest:
+    """Write process, trace, HLS, testbench, and manifest artifacts."""
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    artifact_stem = stem or process.process_id
+    rendered = render_temporal_artifact_from_trace(process, golden_trace)
+
+    process_path = output_path / f"{artifact_stem}_process.json"
+    trace_path = output_path / f"{artifact_stem}_trace.json"
+    hls_path = output_path / f"{artifact_stem}.cpp"
+    testbench_path = output_path / f"{artifact_stem}_tb.cpp"
+    manifest_path = output_path / f"{artifact_stem}_manifest.json"
+
+    process_path.write_text(
+        json.dumps(process.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    trace_path.write_text(
+        json.dumps(golden_trace.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    hls_path.write_text(rendered.process_hls, encoding="utf-8")
+    testbench_path.write_text(rendered.testbench_hls, encoding="utf-8")
+
+    manifest = TemporalHLSArtifactManifest(
+        process_id=process.process_id,
+        files=(
+            TemporalArtifactFile(TemporalArtifactKind.PROCESS_JSON, process_path),
+            TemporalArtifactFile(TemporalArtifactKind.GOLDEN_TRACE_JSON, trace_path),
+            TemporalArtifactFile(TemporalArtifactKind.PROCESS_HLS, hls_path),
+            TemporalArtifactFile(TemporalArtifactKind.TESTBENCH_HLS, testbench_path),
+            TemporalArtifactFile(TemporalArtifactKind.MANIFEST_JSON, manifest_path),
+        ),
+    )
+    manifest_path.write_text(
+        json.dumps(manifest.to_dict(output_path), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
 def load_and_render_temporal_artifact(
     process: Process,
     golden_trace_path: str | PathLike[str],
@@ -161,9 +249,13 @@ def load_and_render_temporal_artifact(
 
 
 __all__ = [
+    "TemporalArtifactFile",
+    "TemporalArtifactKind",
     "TemporalHLSArtifact",
+    "TemporalHLSArtifactManifest",
     "load_and_render_temporal_artifact",
     "render_temporal_artifact_from_trace",
     "render_temporal_process_hls",
     "render_temporal_testbench",
+    "write_temporal_hls_artifact_bundle",
 ]

--- a/src/tempo_dag/codegen/hls/temporal_generator.py
+++ b/src/tempo_dag/codegen/hls/temporal_generator.py
@@ -108,8 +108,10 @@ def render_temporal_process_hls(process: Process) -> str:
             "",
             *edge_delta_comments,
             "",
+            *[line for block in operator_blocks for line in block.splitlines()],
+            "",
             f"void {process.process_id}_step() {{",
-            *[f"  {line}" for block in operator_blocks for line in block.splitlines()],
+            "  // Operator invocation wiring is emitted by the next scheduler layer.",
             "}",
             "",
         ]

--- a/src/tempo_dag/examples/temporal_demo.py
+++ b/src/tempo_dag/examples/temporal_demo.py
@@ -9,7 +9,7 @@ import torch
 import torch.nn as nn
 
 from tempo_dag.codegen.hls.temporal_generator import (
-    render_temporal_artifact_from_trace,
+    write_temporal_hls_artifact_bundle,
 )
 from tempo_dag.numerical_parity import quantize_array
 from tempo_dag.parsers.temporal_onnx import (
@@ -49,6 +49,7 @@ class TemporalDemoReport:
     process_id: str
     buffers: list[str]
     generated_files: list[str]
+    manifest_path: str
     num_trace_steps: int
     validation_passed: bool
     max_state_abs: float
@@ -128,26 +129,16 @@ def run_demo(output_dir: Path = OUTPUT_DIR) -> TemporalDemoReport:
     validator = GoldenTraceValidator()
     validation = validator.validate(golden_trace, quantized_trace)
 
-    artifact = render_temporal_artifact_from_trace(lowering.process, golden_trace)
-
     onnx_path = output_dir / "temporal_demo.onnx"
-    golden_trace_path = output_dir / "temporal_demo_trace.json"
-    process_path = output_dir / "temporal_demo_process.json"
-    hls_path = output_dir / "temporal_demo.cpp"
-    testbench_path = output_dir / "temporal_demo_tb.cpp"
     report_path = output_dir / "temporal_demo_report.json"
 
     onnx.save(model, onnx_path)
-    golden_trace_path.write_text(
-        json.dumps(golden_trace.to_dict(), indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+    manifest = write_temporal_hls_artifact_bundle(
+        lowering.process,
+        golden_trace,
+        output_dir,
+        stem="temporal_demo",
     )
-    process_path.write_text(
-        json.dumps(lowering.process.to_dict(), indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-    hls_path.write_text(artifact.process_hls, encoding="utf-8")
-    testbench_path.write_text(artifact.testbench_hls, encoding="utf-8")
 
     step_metrics = _build_step_metrics(
         fp_trace,
@@ -168,12 +159,10 @@ def run_demo(output_dir: Path = OUTPUT_DIR) -> TemporalDemoReport:
         buffers=sorted(lowering.process.buffers),
         generated_files=[
             str(onnx_path),
-            str(golden_trace_path),
-            str(process_path),
-            str(hls_path),
-            str(testbench_path),
+            *(str(artifact.path) for artifact in manifest.files),
             str(report_path),
         ],
+        manifest_path=str(output_dir / "temporal_demo_manifest.json"),
         num_trace_steps=len(golden_trace.steps),
         validation_passed=bool(validation["pass"]),
         max_state_abs=float(max_state_abs),

--- a/src/tempo_dag/ops/builtins.py
+++ b/src/tempo_dag/ops/builtins.py
@@ -407,6 +407,15 @@ class ReductionOperator(BuiltinOperator):
         context = super().hls_context(values)
         input_value = self._input_values(values)[0]
         output_value = self._output_value(values)
+        reduction_axes = self._reduction_axes(input_value)
+        expected_suffix_axes = list(
+            range(len(input_value.shape) - len(reduction_axes), len(input_value.shape))
+        )
+        if reduction_axes != expected_suffix_axes:
+            raise InvalidOperatorInstanceError(
+                f"{self.op_type} HLS template currently supports contiguous "
+                "suffix reductions only"
+            )
         input_size = _shape_product(input_value.shape)
         output_size = _shape_product(output_value.shape)
         reduction_size = input_size // max(1, output_size)
@@ -985,6 +994,23 @@ class Conv1D(BuiltinOperator):
         batch, in_channels, input_length = input_value.shape
         out_channels, _, kernel_width = weight_value.shape
         output_length = self._output_value(values).shape[2]
+        bias_parameter = ""
+        bias_init = f"({context['cpp_dtype']})0"
+        if rest:
+            bias = rest[0]
+            if bias.vtype is ValueType.SCALAR:
+                bias_size = 1
+                bias_index = "0"
+            elif bias.shape in ([out_channels], [1, out_channels, 1]):
+                bias_size = _shape_product(bias.shape)
+                bias_index = "out_channel"
+            else:
+                raise InvalidOperatorInstanceError(
+                    f"{self.op_type} HLS template supports scalar, "
+                    f"[{out_channels}], or [1, {out_channels}, 1] bias only"
+                )
+            bias_parameter = f",\n    const {context['cpp_dtype']} bias[{bias_size}]"
+            bias_init = f"bias[{bias_index}]"
         context.update(
             {
                 "batch": batch,
@@ -997,6 +1023,8 @@ class Conv1D(BuiltinOperator):
                 "padding": self._optional_int_attr("padding", 0),
                 "dilation": self._optional_int_attr("dilation", 1),
                 "has_bias": _cpp_bool(bool(rest)),
+                "bias_parameter": bias_parameter,
+                "bias_init": bias_init,
             }
         )
         return context
@@ -1218,6 +1246,36 @@ class LSTM(BuiltinOperator):
             )
 
         num_directions = 2 if direction == "bidirectional" else 1
+        bias_parameter = ""
+        gate_biases = {
+            "gate_i_bias": f"({context['cpp_dtype']})0",
+            "gate_o_bias": f"({context['cpp_dtype']})0",
+            "gate_f_bias": f"({context['cpp_dtype']})0",
+            "gate_c_bias": f"({context['cpp_dtype']})0",
+        }
+        if len(input_values) > 3:
+            bias_parameter = (
+                f",\n    const {context['cpp_dtype']} "
+                f"b[{num_directions}][{hidden_size * 8}]"
+            )
+            gate_biases = {
+                "gate_i_bias": (
+                    "b[direction][hidden_idx] + "
+                    f"b[direction][4 * {hidden_size} + hidden_idx]"
+                ),
+                "gate_o_bias": (
+                    f"b[direction][{hidden_size} + hidden_idx] + "
+                    f"b[direction][5 * {hidden_size} + hidden_idx]"
+                ),
+                "gate_f_bias": (
+                    f"b[direction][2 * {hidden_size} + hidden_idx] + "
+                    f"b[direction][6 * {hidden_size} + hidden_idx]"
+                ),
+                "gate_c_bias": (
+                    f"b[direction][3 * {hidden_size} + hidden_idx] + "
+                    f"b[direction][7 * {hidden_size} + hidden_idx]"
+                ),
+            }
         context.update(
             {
                 "seq_len": seq_len,
@@ -1227,6 +1285,8 @@ class LSTM(BuiltinOperator):
                 "num_directions": num_directions,
                 "has_bias": _cpp_bool(len(input_values) > 3),
                 "reverse_direction": _cpp_bool(direction == "reverse"),
+                "bias_parameter": bias_parameter,
+                **gate_biases,
             }
         )
         return context

--- a/src/tempo_dag/ops/builtins.py
+++ b/src/tempo_dag/ops/builtins.py
@@ -30,6 +30,21 @@ def _shape_product(shape: Sequence[int]) -> int:
     return product
 
 
+def _cpp_dtype(dtype: str) -> str:
+    return {
+        "float16": "half",
+        "float32": "float",
+        "float64": "double",
+        "int16": "std::int16_t",
+        "int32": "std::int32_t",
+        "int64": "std::int64_t",
+    }.get(dtype, dtype)
+
+
+def _cpp_bool(value: bool) -> str:
+    return "true" if value else "false"
+
+
 def _is_int_sequence(value: object) -> TypeGuard[Sequence[int]]:
     return (
         isinstance(value, Sequence)
@@ -53,6 +68,7 @@ class BuiltinOperator(Operator):
         output_values = [
             self._lookup_value(values, value_id, "output") for value_id in self.outputs
         ]
+        primary_output = output_values[0] if output_values else None
         return {
             "op_id": self.op_id,
             "op_type": self.op_type,
@@ -61,6 +77,26 @@ class BuiltinOperator(Operator):
             "attrs": dict(self.attrs),
             "input_shapes": [value.shape for value in input_values],
             "output_shapes": [value.shape for value in output_values],
+            "cpp_dtype": _cpp_dtype(
+                primary_output.dtype
+                if primary_output is not None
+                else (input_values[0].dtype if input_values else "float32")
+            ),
+            "input_0_size": (
+                _shape_product(input_values[0].shape) if len(input_values) > 0 else 0
+            ),
+            "input_1_size": (
+                _shape_product(input_values[1].shape) if len(input_values) > 1 else 0
+            ),
+            "output_0_size": (
+                _shape_product(output_values[0].shape) if len(output_values) > 0 else 0
+            ),
+            "has_scalar_lhs": _cpp_bool(
+                len(input_values) > 0 and input_values[0].vtype is ValueType.SCALAR
+            ),
+            "has_scalar_rhs": _cpp_bool(
+                len(input_values) > 1 and input_values[1].vtype is ValueType.SCALAR
+            ),
         }
 
     def _require_input_count(self, allowed: int | Iterable[int]) -> None:
@@ -367,6 +403,22 @@ class ReductionOperator(BuiltinOperator):
             metadata={"heuristic": "reduction"},
         )
 
+    def hls_context(self, values: Mapping[str, Value]) -> dict[str, object]:
+        context = super().hls_context(values)
+        input_value = self._input_values(values)[0]
+        output_value = self._output_value(values)
+        input_size = _shape_product(input_value.shape)
+        output_size = _shape_product(output_value.shape)
+        reduction_size = input_size // max(1, output_size)
+        context.update(
+            {
+                "input_size": input_size,
+                "output_size": output_size,
+                "reduction_size": reduction_size,
+            }
+        )
+        return context
+
 
 class Add(BinaryElementwiseOperator):
     OP_TYPE = "Add"
@@ -451,6 +503,25 @@ class Softmax(BuiltinOperator):
             metadata={"heuristic": "softmax"},
         )
 
+    def hls_context(self, values: Mapping[str, Value]) -> dict[str, object]:
+        context = super().hls_context(values)
+        input_value = self._input_values(values)[0]
+        axis = self._resolve_axis(
+            self._optional_int_attr("axis", -1),
+            len(input_value.shape),
+        )
+        axis_size = input_value.shape[axis]
+        outer_size = _shape_product(input_value.shape[:axis])
+        inner_size = _shape_product(input_value.shape[axis + 1 :])
+        context.update(
+            {
+                "axis_size": axis_size,
+                "outer_size": outer_size,
+                "inner_size": inner_size,
+            }
+        )
+        return context
+
 
 class Sum(ReductionOperator):
     OP_TYPE = "Sum"
@@ -509,6 +580,18 @@ class MatMul(BuiltinOperator):
             metadata={"heuristic": "matmul"},
         )
 
+    def hls_context(self, values: Mapping[str, Value]) -> dict[str, object]:
+        context = super().hls_context(values)
+        lhs, rhs = self._input_values(values)
+        context.update(
+            {
+                "m_dim": lhs.shape[0],
+                "k_dim": lhs.shape[1],
+                "n_dim": rhs.shape[1],
+            }
+        )
+        return context
+
 
 class Transpose(BuiltinOperator):
     OP_TYPE = "Transpose"
@@ -554,6 +637,23 @@ class Transpose(BuiltinOperator):
             metadata={"heuristic": "transpose"},
         )
 
+    def hls_context(self, values: Mapping[str, Value]) -> dict[str, object]:
+        context = super().hls_context(values)
+        input_value = self._input_values(values)[0]
+        perm = self._require_int_sequence_attr("perm")
+        if len(input_value.shape) != 2 or perm != [1, 0]:
+            raise InvalidOperatorInstanceError(
+                f"{self.op_type} HLS template currently supports rank-2 "
+                "matrix transpose with perm [1, 0]"
+            )
+        context.update(
+            {
+                "rows": input_value.shape[0],
+                "cols": input_value.shape[1],
+            }
+        )
+        return context
+
 
 class Reshape(BuiltinOperator):
     OP_TYPE = "Reshape"
@@ -598,6 +698,11 @@ class Reshape(BuiltinOperator):
             ff=max(1, work // 4),
             metadata={"heuristic": "reshape"},
         )
+
+    def hls_context(self, values: Mapping[str, Value]) -> dict[str, object]:
+        context = super().hls_context(values)
+        context["num_elements"] = self._output_work(values)
+        return context
 
 
 class Concat(BuiltinOperator):
@@ -652,6 +757,20 @@ class Concat(BuiltinOperator):
             metadata={"heuristic": "concat"},
         )
 
+    def hls_context(self, values: Mapping[str, Value]) -> dict[str, object]:
+        context = super().hls_context(values)
+        input_values = self._input_values(values)
+        context.update(
+            {
+                "num_inputs": len(input_values),
+                "input_sizes_csv": ", ".join(
+                    str(_shape_product(value.shape)) for value in input_values
+                ),
+                "output_size": self._output_work(values),
+            }
+        )
+        return context
+
 
 class Slice(BuiltinOperator):
     OP_TYPE = "Slice"
@@ -698,6 +817,28 @@ class Slice(BuiltinOperator):
             metadata={"heuristic": "slice"},
         )
 
+    def hls_context(self, values: Mapping[str, Value]) -> dict[str, object]:
+        context = super().hls_context(values)
+        input_value = self._input_values(values)[0]
+        axis = self._resolve_axis(
+            self._require_int_attr("axis"),
+            len(input_value.shape),
+        )
+        if axis != 0 or len(input_value.shape) != 1:
+            raise InvalidOperatorInstanceError(
+                f"{self.op_type} HLS template currently supports rank-1 slices "
+                "along axis 0"
+            )
+        context.update(
+            {
+                "start": self._require_int_attr("start"),
+                "end": self._require_int_attr("end"),
+                "step": self._optional_int_attr("step", 1),
+                "output_size": self._output_work(values),
+            }
+        )
+        return context
+
 
 class LayerNorm(BuiltinOperator):
     OP_TYPE = "LayerNorm"
@@ -727,6 +868,24 @@ class LayerNorm(BuiltinOperator):
             ff=max(2, work * 2),
             metadata={"heuristic": "layer_norm"},
         )
+
+    def hls_context(self, values: Mapping[str, Value]) -> dict[str, object]:
+        context = super().hls_context(values)
+        input_value = self._input_values(values)[0]
+        axis = self._resolve_axis(
+            self._optional_int_attr("axis", -1),
+            len(input_value.shape),
+        )
+        normalized_size = _shape_product(input_value.shape[axis:])
+        outer_size = _shape_product(input_value.shape[:axis])
+        context.update(
+            {
+                "normalized_size": normalized_size,
+                "outer_size": outer_size,
+                "epsilon": self.attrs.get("epsilon", 1e-5),
+            }
+        )
+        return context
 
 
 class Conv1D(BuiltinOperator):
@@ -820,6 +979,28 @@ class Conv1D(BuiltinOperator):
             metadata={"heuristic": "conv1d"},
         )
 
+    def hls_context(self, values: Mapping[str, Value]) -> dict[str, object]:
+        context = super().hls_context(values)
+        input_value, weight_value, *rest = self._input_values(values)
+        batch, in_channels, input_length = input_value.shape
+        out_channels, _, kernel_width = weight_value.shape
+        output_length = self._output_value(values).shape[2]
+        context.update(
+            {
+                "batch": batch,
+                "in_channels": in_channels,
+                "input_length": input_length,
+                "out_channels": out_channels,
+                "kernel_width": kernel_width,
+                "output_length": output_length,
+                "stride": self._optional_int_attr("stride", 1),
+                "padding": self._optional_int_attr("padding", 0),
+                "dilation": self._optional_int_attr("dilation", 1),
+                "has_bias": _cpp_bool(bool(rest)),
+            }
+        )
+        return context
+
 
 class Pad(BuiltinOperator):
     OP_TYPE = "Pad"
@@ -863,6 +1044,24 @@ class Pad(BuiltinOperator):
             metadata={"heuristic": "pad"},
         )
 
+    def hls_context(self, values: Mapping[str, Value]) -> dict[str, object]:
+        context = super().hls_context(values)
+        input_value = self._input_values(values)[0]
+        if len(input_value.shape) != 1:
+            raise InvalidOperatorInstanceError(
+                f"{self.op_type} HLS template currently supports rank-1 padding"
+            )
+        pads = self._require_int_sequence_attr("pads")
+        context.update(
+            {
+                "input_size": _shape_product(input_value.shape),
+                "output_size": self._output_work(values),
+                "pad_before": pads[0] if pads else 0,
+                "pad_after": pads[len(pads) // 2] if pads else 0,
+            }
+        )
+        return context
+
 
 class Shift(BuiltinOperator):
     OP_TYPE = "Shift"
@@ -897,6 +1096,16 @@ class Shift(BuiltinOperator):
             ff=max(1, work // 2),
             metadata={"heuristic": "shift"},
         )
+
+    def hls_context(self, values: Mapping[str, Value]) -> dict[str, object]:
+        context = super().hls_context(values)
+        context.update(
+            {
+                "amount": self._require_int_attr("amount"),
+                "output_size": self._output_work(values),
+            }
+        )
+        return context
 
 
 class LSTM(BuiltinOperator):
@@ -938,10 +1147,15 @@ class LSTM(BuiltinOperator):
                 f"got {r.shape}"
             )
 
-        # Optional inputs
-        if len(input_values) > 3:  # Bias
-            # ... bias validation if needed
-            pass
+        if len(input_values) > 3:
+            bias = input_values[3]
+            self._require_tensor(bias, "input[3] (B)")
+            expected_bias_shape = [num_directions, 8 * hidden_size]
+            if bias.shape != expected_bias_shape:
+                raise InvalidOperatorInstanceError(
+                    f"{self.op_type} expects bias B shape {expected_bias_shape}, "
+                    f"got {bias.shape}"
+                )
 
         # Validate outputs
         output_values = [
@@ -980,6 +1194,42 @@ class LSTM(BuiltinOperator):
             ff=max(100, hidden_size * 10),
             metadata={"heuristic": "lstm"},
         )
+
+    def hls_context(self, values: Mapping[str, Value]) -> dict[str, object]:
+        context = super().hls_context(values)
+        input_values = self._input_values(values)
+        x, _, _ = input_values[:3]
+        seq_len, batch, input_size = x.shape
+        hidden_size = self._require_int_attr("hidden_size")
+        direction = self.attrs.get("direction", "forward")
+        if direction not in ("forward", "reverse", "bidirectional"):
+            raise InvalidOperatorInstanceError(
+                f"{self.op_type} requires direction to be forward, reverse, "
+                "or bidirectional"
+            )
+        if len(input_values) > 4:
+            raise InvalidOperatorInstanceError(
+                f"{self.op_type} HLS template currently supports X, W, R, "
+                "and optional B inputs only"
+            )
+        if len(self.outputs) != 1:
+            raise InvalidOperatorInstanceError(
+                f"{self.op_type} HLS template currently emits the Y output only"
+            )
+
+        num_directions = 2 if direction == "bidirectional" else 1
+        context.update(
+            {
+                "seq_len": seq_len,
+                "batch": batch,
+                "input_size": input_size,
+                "hidden_size": hidden_size,
+                "num_directions": num_directions,
+                "has_bias": _cpp_bool(len(input_values) > 3),
+                "reverse_direction": _cpp_bool(direction == "reverse"),
+            }
+        )
+        return context
 
 
 BUILTIN_OPERATORS = [

--- a/tests/integration/test_temporal_demo_pipeline.py
+++ b/tests/integration/test_temporal_demo_pipeline.py
@@ -18,6 +18,9 @@ def test_temporal_demo_pipeline_emits_artifacts() -> None:
     assert (output_dir / "temporal_demo.cpp").is_file()
     assert (output_dir / "temporal_demo_tb.cpp").is_file()
     assert (output_dir / "temporal_demo_trace.json").is_file()
+    assert (output_dir / "temporal_demo_process.json").is_file()
+    assert (output_dir / "temporal_demo_manifest.json").is_file()
+    assert report.manifest_path == str(output_dir / "temporal_demo_manifest.json")
 
 
 def test_temporal_lowering_connects_to_trace_driven_hls() -> None:

--- a/tests/unit/test_hls_cpp_smoke.py
+++ b/tests/unit/test_hls_cpp_smoke.py
@@ -108,6 +108,44 @@ def test_representative_hls_operator_templates_compile_as_cpp(
     _compile_cpp(compiler, tmp_path / "operators.cpp", translation_unit)
 
 
+def test_hls_operator_templates_execute_against_golden_data(tmp_path: Path) -> None:
+    compiler = _cpp_compiler()
+    snippets = [
+        _render_binary(Add(op_id="add_0", inputs=["lhs", "rhs"], outputs=["out"])),
+        _render_add_scalar_rhs(),
+        _render_binary(Sub(op_id="sub_0", inputs=["lhs", "rhs"], outputs=["out"])),
+        _render_binary(Mul(op_id="mul_0", inputs=["lhs", "rhs"], outputs=["out"])),
+        _render_binary(Div(op_id="div_0", inputs=["lhs", "rhs"], outputs=["out"])),
+        _render_unary(ReLU(op_id="relu_0", inputs=["x"], outputs=["y"])),
+        _render_reduction(Sum(op_id="sum_0", inputs=["x"], outputs=["y"])),
+        _render_reduction(Mean(op_id="mean_0", inputs=["x"], outputs=["y"])),
+        _render_reduction(Max(op_id="max_0", inputs=["x"], outputs=["y"])),
+        _render_softmax(),
+        _render_matmul(),
+        _render_transpose(),
+        _render_reshape(),
+        _render_concat(),
+        _render_slice(),
+        _render_layer_norm(),
+        _render_pad(),
+        _render_shift(),
+        _render_shift_left(),
+        _render_lstm(),
+    ]
+    translation_unit = "\n\n".join(
+        [
+            "#include <cmath>",
+            "#include <cstdint>",
+            "#include <iostream>",
+            *snippets,
+            _golden_runtime_main(),
+            "",
+        ]
+    )
+
+    _compile_and_run_cpp(compiler, tmp_path / "operator_golden.cpp", translation_unit)
+
+
 def test_temporal_hls_artifact_compiles_with_testbench(tmp_path: Path) -> None:
     compiler = _cpp_compiler()
     process = (
@@ -164,6 +202,18 @@ def _render_binary(operator: Operator) -> str:
         "out": make_tensor("out", [2, 3], ["batch", "feature"]),
     }
     return render_operator_hls(operator, values)
+
+
+def _render_add_scalar_rhs() -> str:
+    values = {
+        "lhs": make_tensor("lhs", [3], ["feature"]),
+        "rhs": make_scalar("rhs"),
+        "out": make_tensor("out", [3], ["feature"]),
+    }
+    return render_operator_hls(
+        Add(op_id="add_scalar_0", inputs=["lhs", "rhs"], outputs=["out"]),
+        values,
+    )
 
 
 def _render_unary(operator: Operator) -> str:
@@ -316,6 +366,22 @@ def _render_shift() -> str:
     )
 
 
+def _render_shift_left() -> str:
+    values = {
+        "x": make_tensor("x", [4], ["feature"]),
+        "y": make_tensor("y", [4], ["feature"]),
+    }
+    return render_operator_hls(
+        Shift(
+            op_id="shift_left_0",
+            inputs=["x"],
+            outputs=["y"],
+            attrs={"axis": 0, "amount": -1},
+        ),
+        values,
+    )
+
+
 def _render_lstm() -> str:
     values = {
         "x": make_tensor("x", [3, 1, 2], ["time", "batch", "feature"]),
@@ -332,6 +398,147 @@ def _render_lstm() -> str:
         ),
         values,
     )
+
+
+def _golden_runtime_main() -> str:
+    return r"""
+bool approx_equal(float lhs, float rhs, float tolerance = 1.0e-4f) {
+  return std::fabs(lhs - rhs) <= tolerance;
+}
+
+bool check_array(const char* name, const float* actual, const float* expected,
+                 int size, float tolerance = 1.0e-4f) {
+  for (int idx = 0; idx < size; ++idx) {
+    if (!approx_equal(actual[idx], expected[idx], tolerance)) {
+      std::cerr << name << "[" << idx << "] expected " << expected[idx]
+                << " got " << actual[idx] << "\n";
+      return false;
+    }
+  }
+  return true;
+}
+
+int main() {
+  bool ok = true;
+
+  float lhs[6] = {1.0f, -2.0f, 0.0f, 4.5f, -1.0f, 3.0f};
+  float rhs[6] = {2.0f, 2.0f, -1.0f, 0.5f, 1.0f, -3.0f};
+  float out6[6] = {};
+
+  add_0_kernel(lhs, rhs, out6);
+  const float add_expected[6] = {3.0f, 0.0f, -1.0f, 5.0f, 0.0f, 0.0f};
+  ok = check_array("add", out6, add_expected, 6) && ok;
+
+  float scalar_rhs[1] = {2.5f};
+  float lhs3[3] = {-1.0f, 0.0f, 4.0f};
+  float out3[3] = {};
+  add_scalar_0_kernel(lhs3, scalar_rhs, out3);
+  const float add_scalar_expected[3] = {1.5f, 2.5f, 6.5f};
+  ok = check_array("add_scalar", out3, add_scalar_expected, 3) && ok;
+
+  sub_0_kernel(lhs, rhs, out6);
+  const float sub_expected[6] = {-1.0f, -4.0f, 1.0f, 4.0f, -2.0f, 6.0f};
+  ok = check_array("sub", out6, sub_expected, 6) && ok;
+
+  mul_0_kernel(lhs, rhs, out6);
+  const float mul_expected[6] = {2.0f, -4.0f, -0.0f, 2.25f, -1.0f, -9.0f};
+  ok = check_array("mul", out6, mul_expected, 6) && ok;
+
+  div_0_kernel(lhs, rhs, out6);
+  const float div_expected[6] = {0.5f, -1.0f, -0.0f, 9.0f, -1.0f, -1.0f};
+  ok = check_array("div", out6, div_expected, 6) && ok;
+
+  relu_0_kernel(lhs, out6);
+  const float relu_expected[6] = {1.0f, 0.0f, 0.0f, 4.5f, 0.0f, 3.0f};
+  ok = check_array("relu", out6, relu_expected, 6) && ok;
+
+  float reduction_input[6] = {1.0f, 2.0f, 3.0f, -1.0f, -5.0f, 4.0f};
+  float reduction_out[2] = {};
+  sum_0_kernel(reduction_input, reduction_out);
+  const float sum_expected[2] = {6.0f, -2.0f};
+  ok = check_array("sum", reduction_out, sum_expected, 2) && ok;
+  mean_0_kernel(reduction_input, reduction_out);
+  const float mean_expected[2] = {2.0f, -0.6666667f};
+  ok = check_array("mean", reduction_out, mean_expected, 2) && ok;
+  max_0_kernel(reduction_input, reduction_out);
+  const float max_expected[2] = {3.0f, 4.0f};
+  ok = check_array("max", reduction_out, max_expected, 2) && ok;
+
+  float softmax_input[6] = {0.0f, 0.0f, 0.0f, 2.0f, 1.0f, 0.0f};
+  softmax_0_kernel(softmax_input, out6);
+  const float softmax_expected[6] = {
+      0.3333333f, 0.3333333f, 0.3333333f,
+      0.6652409f, 0.2447285f, 0.0900306f};
+  ok = check_array("softmax", out6, softmax_expected, 6, 1.0e-3f) && ok;
+
+  float mat_lhs[2][3] = {{1.0f, 2.0f, 3.0f}, {-1.0f, 0.0f, 2.0f}};
+  float mat_rhs[3][4] = {
+      {1.0f, 0.0f, 2.0f, -1.0f},
+      {0.0f, 1.0f, -1.0f, 2.0f},
+      {3.0f, 1.0f, 0.0f, 1.0f}};
+  float mat_out[2][4] = {};
+  matmul_0_kernel(mat_lhs, mat_rhs, mat_out);
+  const float mat_expected[8] = {10.0f, 5.0f, 0.0f, 6.0f,
+                                 5.0f, 2.0f, -2.0f, 3.0f};
+  ok = check_array("matmul", &mat_out[0][0], mat_expected, 8) && ok;
+
+  float transpose_input[2][3] = {{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}};
+  float transpose_out[3][2] = {};
+  transpose_0_kernel(transpose_input, transpose_out);
+  const float transpose_expected[6] = {1.0f, 4.0f, 2.0f, 5.0f, 3.0f, 6.0f};
+  ok = check_array("transpose", &transpose_out[0][0], transpose_expected, 6) && ok;
+
+  reshape_0_kernel(transpose_input[0], out6);
+  const float reshape_expected[6] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  ok = check_array("reshape", out6, reshape_expected, 6) && ok;
+
+  float concat_a[2] = {7.0f, 8.0f};
+  float concat_b[3] = {-1.0f, -2.0f, -3.0f};
+  const float* concat_inputs[2] = {concat_a, concat_b};
+  float concat_out[5] = {};
+  concat_0_kernel(concat_inputs, concat_out);
+  const float concat_expected[5] = {7.0f, 8.0f, -1.0f, -2.0f, -3.0f};
+  ok = check_array("concat", concat_out, concat_expected, 5) && ok;
+
+  float slice_input[6] = {10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f};
+  float slice_out[2] = {};
+  slice_0_kernel(slice_input, slice_out);
+  const float slice_expected[2] = {20.0f, 40.0f};
+  ok = check_array("slice", slice_out, slice_expected, 2) && ok;
+
+  float layer_input[6] = {1.0f, 2.0f, 3.0f, 2.0f, 2.0f, 2.0f};
+  layer_norm_0_kernel(layer_input, out6);
+  const float layer_expected[6] = {-1.2247356f, 0.0f, 1.2247356f,
+                                   0.0f, 0.0f, 0.0f};
+  ok = check_array("layer_norm", out6, layer_expected, 6, 1.0e-3f) && ok;
+
+  float pad_input[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+  float pad_out[7] = {};
+  pad_0_kernel(pad_input, pad_out);
+  const float pad_expected[7] = {0.0f, 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 0.0f};
+  ok = check_array("pad", pad_out, pad_expected, 7) && ok;
+
+  float shift_input[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+  float shift_out[4] = {};
+  shift_0_kernel(shift_input, shift_out);
+  const float shift_expected[4] = {0.0f, 1.0f, 2.0f, 3.0f};
+  ok = check_array("shift", shift_out, shift_expected, 4) && ok;
+  shift_left_0_kernel(shift_input, shift_out);
+  const float shift_left_expected[4] = {2.0f, 3.0f, 4.0f, 0.0f};
+  ok = check_array("shift_left", shift_out, shift_left_expected, 4) && ok;
+
+  float lstm_x[3][1][2] = {};
+  float lstm_w[1][16][2] = {};
+  float lstm_r[1][16][4] = {};
+  float lstm_b[1][32] = {};
+  float lstm_y[3][1][1][4] = {};
+  lstm_0_kernel(lstm_x, lstm_w, lstm_r, lstm_b, lstm_y);
+  const float lstm_expected[12] = {};
+  ok = check_array("lstm_zero", &lstm_y[0][0][0][0], lstm_expected, 12) && ok;
+
+  return ok ? 0 : 1;
+}
+"""
 
 
 def _cpp_compiler() -> str:
@@ -352,3 +559,30 @@ def _compile_cpp(compiler: str, path: Path, source: str) -> None:
     ]
     result = subprocess.run(command, capture_output=True, text=True, check=False)
     assert result.returncode == 0, result.stderr
+
+
+def _compile_and_run_cpp(compiler: str, path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+    executable = path.with_suffix(".exe")
+    command = [
+        compiler,
+        "-std=c++17",
+        "-Wno-unknown-pragmas",
+        str(path),
+        "-o",
+        str(executable),
+    ]
+    compile_result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+    run_result = subprocess.run(
+        [str(executable)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert run_result.returncode == 0, run_result.stderr

--- a/tests/unit/test_hls_cpp_smoke.py
+++ b/tests/unit/test_hls_cpp_smoke.py
@@ -530,9 +530,8 @@ int main() {
   float lstm_x[3][1][2] = {};
   float lstm_w[1][16][2] = {};
   float lstm_r[1][16][4] = {};
-  float lstm_b[1][32] = {};
   float lstm_y[3][1][1][4] = {};
-  lstm_0_kernel(lstm_x, lstm_w, lstm_r, lstm_b, lstm_y);
+  lstm_0_kernel(lstm_x, lstm_w, lstm_r, lstm_y);
   const float lstm_expected[12] = {};
   ok = check_array("lstm_zero", &lstm_y[0][0][0][0], lstm_expected, 12) && ok;
 

--- a/tests/unit/test_hls_cpp_smoke.py
+++ b/tests/unit/test_hls_cpp_smoke.py
@@ -1,0 +1,354 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tempo_dag.codegen.hls.generator import render_operator_hls
+from tempo_dag.codegen.hls.temporal_generator import (
+    render_temporal_artifact_from_trace,
+    render_temporal_process_hls,
+)
+from tempo_dag.ir.op import Operator
+from tempo_dag.ir.value import Value, ValueType
+from tempo_dag.ops.builtins import (
+    GELU,
+    LSTM,
+    Add,
+    Concat,
+    Conv1D,
+    Div,
+    LayerNorm,
+    MatMul,
+    Max,
+    Mean,
+    Mul,
+    Pad,
+    ReLU,
+    Reshape,
+    Shift,
+    Sigmoid,
+    Slice,
+    Softmax,
+    Sub,
+    Sum,
+    Tanh,
+    Transpose,
+)
+from tempo_dag.parsers.temporal_onnx import (
+    TemporalONNXParser,
+    build_demo_temporal_onnx_model,
+)
+from tempo_dag.verification.golden_trace import load_golden_trace
+
+
+def make_tensor(
+    value_id: str,
+    shape: list[int],
+    axes: list[str] | None = None,
+) -> Value:
+    return Value(
+        value_id=value_id,
+        vtype=ValueType.TENSOR,
+        dtype="float32",
+        shape=shape,
+        axes=axes or [f"axis_{idx}" for idx in range(len(shape))],
+    )
+
+
+def make_scalar(value_id: str) -> Value:
+    return Value(
+        value_id=value_id,
+        vtype=ValueType.SCALAR,
+        dtype="float32",
+        shape=[],
+        axes=[],
+    )
+
+
+def test_representative_hls_operator_templates_compile_as_cpp(
+    tmp_path: Path,
+) -> None:
+    compiler = _cpp_compiler()
+
+    snippets = [
+        _render_binary(Add(op_id="add_0", inputs=["lhs", "rhs"], outputs=["out"])),
+        _render_binary(Sub(op_id="sub_0", inputs=["lhs", "rhs"], outputs=["out"])),
+        _render_binary(Mul(op_id="mul_0", inputs=["lhs", "rhs"], outputs=["out"])),
+        _render_binary(Div(op_id="div_0", inputs=["lhs", "rhs"], outputs=["out"])),
+        _render_unary(Sigmoid(op_id="sigmoid_0", inputs=["x"], outputs=["y"])),
+        _render_unary(Tanh(op_id="tanh_0", inputs=["x"], outputs=["y"])),
+        _render_unary(ReLU(op_id="relu_0", inputs=["x"], outputs=["y"])),
+        _render_unary(GELU(op_id="gelu_0", inputs=["x"], outputs=["y"])),
+        _render_reduction(Sum(op_id="sum_0", inputs=["x"], outputs=["y"])),
+        _render_reduction(Mean(op_id="mean_0", inputs=["x"], outputs=["y"])),
+        _render_reduction(Max(op_id="max_0", inputs=["x"], outputs=["y"])),
+        _render_softmax(),
+        _render_matmul(),
+        _render_transpose(),
+        _render_reshape(),
+        _render_concat(),
+        _render_slice(),
+        _render_layer_norm(),
+        _render_conv1d(),
+        _render_pad(),
+        _render_shift(),
+        _render_lstm(),
+    ]
+    translation_unit = "\n\n".join(
+        [
+            "#include <cmath>",
+            "#include <cstdint>",
+            *snippets,
+            "int main() { return 0; }",
+            "",
+        ]
+    )
+
+    _compile_cpp(compiler, tmp_path / "operators.cpp", translation_unit)
+
+
+def test_temporal_hls_artifact_compiles_with_testbench(tmp_path: Path) -> None:
+    compiler = _cpp_compiler()
+    process = (
+        TemporalONNXParser()
+        .parse_model(
+            build_demo_temporal_onnx_model(),
+            process_id="demo_process",
+        )
+        .process
+    )
+    trace = load_golden_trace("tests/verification/golden_traces/rolling_mean.json")
+    artifact = render_temporal_artifact_from_trace(process, trace)
+
+    process_path = tmp_path / "demo_process.cpp"
+    testbench_path = tmp_path / "demo_process_tb.cpp"
+    process_path.write_text(artifact.process_hls, encoding="utf-8")
+    testbench_path.write_text(artifact.testbench_hls, encoding="utf-8")
+
+    command = [
+        compiler,
+        "-std=c++17",
+        "-Wno-unknown-pragmas",
+        str(process_path),
+        str(testbench_path),
+        "-o",
+        str(tmp_path / "demo_process_tb"),
+    ]
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
+def test_temporal_process_hls_emits_operator_kernels_at_file_scope() -> None:
+    process = (
+        TemporalONNXParser()
+        .parse_model(
+            build_demo_temporal_onnx_model(),
+            process_id="demo_process",
+        )
+        .process
+    )
+
+    rendered = render_temporal_process_hls(process)
+
+    assert (
+        "template <typename T, int Window>\nvoid rolling_mean_node_kernel" in rendered
+    )
+    assert "void demo_process_step() {\n  // Operator invocation wiring" in rendered
+
+
+def _render_binary(operator: Operator) -> str:
+    values = {
+        "lhs": make_tensor("lhs", [2, 3], ["batch", "feature"]),
+        "rhs": make_tensor("rhs", [2, 3], ["batch", "feature"]),
+        "out": make_tensor("out", [2, 3], ["batch", "feature"]),
+    }
+    return render_operator_hls(operator, values)
+
+
+def _render_unary(operator: Operator) -> str:
+    values = {
+        "x": make_tensor("x", [2, 3], ["batch", "feature"]),
+        "y": make_tensor("y", [2, 3], ["batch", "feature"]),
+    }
+    return render_operator_hls(operator, values)
+
+
+def _render_reduction(operator: Operator) -> str:
+    values = {
+        "x": make_tensor("x", [2, 3], ["batch", "feature"]),
+        "y": make_tensor("y", [2], ["batch"]),
+    }
+    operator.attrs["axis"] = 1
+    return render_operator_hls(operator, values)
+
+
+def _render_softmax() -> str:
+    values = {
+        "x": make_tensor("x", [2, 3], ["batch", "feature"]),
+        "y": make_tensor("y", [2, 3], ["batch", "feature"]),
+    }
+    return render_operator_hls(
+        Softmax(op_id="softmax_0", inputs=["x"], outputs=["y"], attrs={"axis": 1}),
+        values,
+    )
+
+
+def _render_matmul() -> str:
+    values = {
+        "lhs": make_tensor("lhs", [2, 3], ["rows", "inner"]),
+        "rhs": make_tensor("rhs", [3, 4], ["inner", "cols"]),
+        "out": make_tensor("out", [2, 4], ["rows", "cols"]),
+    }
+    return render_operator_hls(
+        MatMul(op_id="matmul_0", inputs=["lhs", "rhs"], outputs=["out"]),
+        values,
+    )
+
+
+def _render_transpose() -> str:
+    values = {
+        "x": make_tensor("x", [2, 3], ["rows", "cols"]),
+        "y": make_tensor("y", [3, 2], ["cols", "rows"]),
+    }
+    return render_operator_hls(
+        Transpose(
+            op_id="transpose_0",
+            inputs=["x"],
+            outputs=["y"],
+            attrs={"perm": [1, 0]},
+        ),
+        values,
+    )
+
+
+def _render_reshape() -> str:
+    values = {
+        "x": make_tensor("x", [2, 3], ["rows", "cols"]),
+        "y": make_tensor("y", [6], ["flat"]),
+    }
+    return render_operator_hls(
+        Reshape(op_id="reshape_0", inputs=["x"], outputs=["y"], attrs={"shape": [6]}),
+        values,
+    )
+
+
+def _render_concat() -> str:
+    values = {
+        "a": make_tensor("a", [2], ["feature"]),
+        "b": make_tensor("b", [3], ["feature"]),
+        "out": make_tensor("out", [5], ["feature"]),
+    }
+    return render_operator_hls(
+        Concat(op_id="concat_0", inputs=["a", "b"], outputs=["out"], attrs={"axis": 0}),
+        values,
+    )
+
+
+def _render_slice() -> str:
+    values = {
+        "x": make_tensor("x", [6], ["feature"]),
+        "y": make_tensor("y", [2], ["feature"]),
+    }
+    return render_operator_hls(
+        Slice(
+            op_id="slice_0",
+            inputs=["x"],
+            outputs=["y"],
+            attrs={"axis": 0, "start": 1, "end": 5, "step": 2},
+        ),
+        values,
+    )
+
+
+def _render_layer_norm() -> str:
+    values = {
+        "x": make_tensor("x", [2, 3], ["batch", "feature"]),
+        "y": make_tensor("y", [2, 3], ["batch", "feature"]),
+    }
+    return render_operator_hls(
+        LayerNorm(op_id="layer_norm_0", inputs=["x"], outputs=["y"], attrs={"axis": 1}),
+        values,
+    )
+
+
+def _render_conv1d() -> str:
+    values = {
+        "x": make_tensor("x", [1, 2, 8], ["batch", "channel", "time"]),
+        "w": make_tensor("w", [4, 2, 3], ["out_channel", "in_channel", "kernel"]),
+        "y": make_tensor("y", [1, 4, 8], ["batch", "channel", "time"]),
+    }
+    return render_operator_hls(
+        Conv1D(
+            op_id="conv_0",
+            inputs=["x", "w"],
+            outputs=["y"],
+            attrs={"stride": 1, "padding": 1, "dilation": 1},
+        ),
+        values,
+    )
+
+
+def _render_pad() -> str:
+    values = {
+        "x": make_tensor("x", [4], ["feature"]),
+        "y": make_tensor("y", [7], ["feature"]),
+    }
+    return render_operator_hls(
+        Pad(op_id="pad_0", inputs=["x"], outputs=["y"], attrs={"pads": [2, 1]}),
+        values,
+    )
+
+
+def _render_shift() -> str:
+    values = {
+        "x": make_tensor("x", [4], ["feature"]),
+        "y": make_tensor("y", [4], ["feature"]),
+    }
+    return render_operator_hls(
+        Shift(
+            op_id="shift_0",
+            inputs=["x"],
+            outputs=["y"],
+            attrs={"axis": 0, "amount": 1},
+        ),
+        values,
+    )
+
+
+def _render_lstm() -> str:
+    values = {
+        "x": make_tensor("x", [3, 1, 2], ["time", "batch", "feature"]),
+        "w": make_tensor("w", [1, 16, 2], ["direction", "gate_hidden", "feature"]),
+        "r": make_tensor("r", [1, 16, 4], ["direction", "gate_hidden", "hidden"]),
+        "y": make_tensor("y", [3, 1, 1, 4], ["time", "direction", "batch", "hidden"]),
+    }
+    return render_operator_hls(
+        LSTM(
+            op_id="lstm_0",
+            inputs=["x", "w", "r"],
+            outputs=["y"],
+            attrs={"hidden_size": 4},
+        ),
+        values,
+    )
+
+
+def _cpp_compiler() -> str:
+    compiler = shutil.which("g++") or shutil.which("clang++")
+    if compiler is None:
+        pytest.skip("C++ compiler not available for HLS smoke tests")
+    return compiler
+
+
+def _compile_cpp(compiler: str, path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+    command = [
+        compiler,
+        "-std=c++17",
+        "-Wno-unknown-pragmas",
+        "-fsyntax-only",
+        str(path),
+    ]
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/test_hls_renderer.py
+++ b/tests/unit/test_hls_renderer.py
@@ -11,9 +11,9 @@ from tempo_dag.codegen.hls.generator import (
     render_operator_hls,
     resolve_hls_template_path,
 )
-from tempo_dag.ir.op import FPGACost, Operator
+from tempo_dag.ir.op import FPGACost, InvalidOperatorInstanceError, Operator
 from tempo_dag.ir.value import Value, ValueType
-from tempo_dag.ops.builtins import BUILTIN_OPERATORS, LSTM, Add, Conv1D, MatMul
+from tempo_dag.ops.builtins import BUILTIN_OPERATORS, LSTM, Add, Conv1D, MatMul, Sum
 
 
 def make_tensor(value_id, shape, axes=None, dtype="float32"):
@@ -141,8 +141,29 @@ def test_render_operator_hls_renders_conv1d_kernel_shape():
 
     assert "const float input[1][2][8]" in rendered
     assert "const float weight[4][2][3]" in rendered
+    assert "bias" not in rendered.split(") {", maxsplit=1)[0]
     assert "float out[1][4][8]" in rendered
     assert "const int in_t = out_t * 1 + kernel * 1 - 1;" in rendered
+
+
+def test_render_operator_hls_renders_conv1d_bias_abi_when_present():
+    values = {
+        "x": make_tensor("x", [1, 2, 8], ["batch", "channel", "time"]),
+        "w": make_tensor("w", [4, 2, 3], ["out_channel", "in_channel", "kernel"]),
+        "b": make_tensor("b", [1, 4, 1], ["batch", "channel", "time"]),
+        "y": make_tensor("y", [1, 4, 8], ["batch", "channel", "time"]),
+    }
+    operator = Conv1D(
+        op_id="conv_0",
+        inputs=["x", "w", "b"],
+        outputs=["y"],
+        attrs={"stride": 1, "padding": 1, "dilation": 1},
+    )
+
+    rendered = render_operator_hls(operator, values)
+
+    assert "const float bias[4]" in rendered
+    assert "float acc = bias[out_channel];" in rendered
 
 
 def test_render_operator_hls_renders_lstm_template():
@@ -163,8 +184,49 @@ def test_render_operator_hls_renders_lstm_template():
 
     assert "void lstm_0_kernel(" in rendered
     assert "const float x[3][1][2]" in rendered
+    assert " b[" not in rendered.split(") {", maxsplit=1)[0]
     assert "float y[3][1][1][4]" in rendered
     assert "#pragma HLS ARRAY_PARTITION variable=hidden cyclic factor=4" in rendered
+
+
+def test_render_operator_hls_renders_lstm_bias_abi_when_present():
+    values = {
+        "x": make_tensor("x", [3, 1, 2], ["time", "batch", "feature"]),
+        "w": make_tensor("w", [1, 16, 2], ["direction", "gate_hidden", "feature"]),
+        "r": make_tensor("r", [1, 16, 4], ["direction", "gate_hidden", "hidden"]),
+        "b": make_tensor("b", [1, 32], ["direction", "gate_bias"]),
+        "y": make_tensor("y", [3, 1, 1, 4], ["time", "direction", "batch", "hidden"]),
+    }
+    operator = LSTM(
+        op_id="lstm_0",
+        inputs=["x", "w", "r", "b"],
+        outputs=["y"],
+        attrs={"hidden_size": 4},
+    )
+
+    rendered = render_operator_hls(operator, values)
+
+    assert "const float b[1][32]" in rendered
+    assert "float gate_i = b[direction][hidden_idx]" in rendered
+
+
+def test_render_operator_hls_rejects_non_suffix_reduction_for_current_template():
+    values = {
+        "x": make_tensor("x", [2, 3], ["batch", "feature"]),
+        "y": make_tensor("y", [3], ["feature"]),
+    }
+    operator = Sum(
+        op_id="sum_0",
+        inputs=["x"],
+        outputs=["y"],
+        attrs={"axis": 0},
+    )
+
+    with pytest.raises(
+        InvalidOperatorInstanceError,
+        match="contiguous suffix reductions only",
+    ):
+        render_operator_hls(operator, values)
 
 
 def test_render_operator_hls_resolves_custom_template_relative_to_module():

--- a/tests/unit/test_hls_renderer.py
+++ b/tests/unit/test_hls_renderer.py
@@ -13,7 +13,7 @@ from tempo_dag.codegen.hls.generator import (
 )
 from tempo_dag.ir.op import FPGACost, Operator
 from tempo_dag.ir.value import Value, ValueType
-from tempo_dag.ops.builtins import Add
+from tempo_dag.ops.builtins import BUILTIN_OPERATORS, LSTM, Add, Conv1D, MatMul
 
 
 def make_tensor(value_id, shape, axes=None, dtype="float32"):
@@ -84,6 +84,13 @@ def test_resolve_hls_template_path_finds_repo_managed_builtin_template():
     assert template_path == (Path.cwd() / "hls" / "operators" / "add.cpp.tpl").resolve()
 
 
+def test_all_builtin_operator_templates_resolve():
+    for operator_cls in BUILTIN_OPERATORS:
+        operator = operator_cls(op_id="op_0", inputs=[], outputs=[])
+
+        assert resolve_hls_template_path(operator).is_file()
+
+
 def test_render_operator_hls_renders_builtin_template():
     values = {
         "lhs": make_tensor("lhs", [2, 3], ["batch", "feature"]),
@@ -97,6 +104,67 @@ def test_render_operator_hls_renders_builtin_template():
     assert "Operator: Add" in rendered
     assert "Kernel: add_0_kernel" in rendered
     assert "Inputs: ['lhs', 'rhs']" in rendered
+    assert "#pragma HLS PIPELINE II=1" in rendered
+    assert "out[idx] = lhs_value + rhs_value;" in rendered
+
+
+def test_render_operator_hls_renders_matmul_loop_pragmas():
+    values = {
+        "lhs": make_tensor("lhs", [2, 3], ["rows", "inner"]),
+        "rhs": make_tensor("rhs", [3, 4], ["inner", "cols"]),
+        "out": make_tensor("out", [2, 4], ["rows", "cols"]),
+    }
+    operator = MatMul(op_id="matmul_0", inputs=["lhs", "rhs"], outputs=["out"])
+
+    rendered = render_operator_hls(operator, values)
+
+    assert "const float lhs[2][3]" in rendered
+    assert "const float rhs[3][4]" in rendered
+    assert "#pragma HLS UNROLL factor=4" in rendered
+    assert "out[row][col] = acc;" in rendered
+
+
+def test_render_operator_hls_renders_conv1d_kernel_shape():
+    values = {
+        "x": make_tensor("x", [1, 2, 8], ["batch", "channel", "time"]),
+        "w": make_tensor("w", [4, 2, 3], ["out_channel", "in_channel", "kernel"]),
+        "y": make_tensor("y", [1, 4, 8], ["batch", "channel", "time"]),
+    }
+    operator = Conv1D(
+        op_id="conv_0",
+        inputs=["x", "w"],
+        outputs=["y"],
+        attrs={"stride": 1, "padding": 1, "dilation": 1},
+    )
+
+    rendered = render_operator_hls(operator, values)
+
+    assert "const float input[1][2][8]" in rendered
+    assert "const float weight[4][2][3]" in rendered
+    assert "float out[1][4][8]" in rendered
+    assert "const int in_t = out_t * 1 + kernel * 1 - 1;" in rendered
+
+
+def test_render_operator_hls_renders_lstm_template():
+    values = {
+        "x": make_tensor("x", [3, 1, 2], ["time", "batch", "feature"]),
+        "w": make_tensor("w", [1, 16, 2], ["direction", "gate_hidden", "feature"]),
+        "r": make_tensor("r", [1, 16, 4], ["direction", "gate_hidden", "hidden"]),
+        "y": make_tensor("y", [3, 1, 1, 4], ["time", "direction", "batch", "hidden"]),
+    }
+    operator = LSTM(
+        op_id="lstm_0",
+        inputs=["x", "w", "r"],
+        outputs=["y"],
+        attrs={"hidden_size": 4},
+    )
+
+    rendered = render_operator_hls(operator, values)
+
+    assert "void lstm_0_kernel(" in rendered
+    assert "const float x[3][1][2]" in rendered
+    assert "float y[3][1][1][4]" in rendered
+    assert "#pragma HLS ARRAY_PARTITION variable=hidden cyclic factor=4" in rendered
 
 
 def test_render_operator_hls_resolves_custom_template_relative_to_module():

--- a/tests/unit/test_temporal_hls.py
+++ b/tests/unit/test_temporal_hls.py
@@ -1,8 +1,13 @@
+import json
+import tempfile
 from dataclasses import replace
+from pathlib import Path
 
 from tempo_dag.codegen.hls.temporal_generator import (
+    TemporalArtifactKind,
     render_temporal_artifact_from_trace,
     render_temporal_process_hls,
+    write_temporal_hls_artifact_bundle,
 )
 from tempo_dag.examples import rolling_window_process
 from tempo_dag.parsers.temporal_onnx import (
@@ -75,3 +80,43 @@ def test_render_temporal_process_hls_includes_execution_contract_comments() -> N
     assert "// edge_delta_storage: feature_kernel->rolling_window@1:x" in rendered
     assert "-> register latency=1" in rendered
     assert "// buffer_storage: rolling_window -> ring_buffer latency=8" in rendered
+
+
+def test_write_temporal_hls_artifact_bundle_emits_manifest_and_files() -> None:
+    process = (
+        TemporalONNXParser()
+        .parse_model(
+            build_demo_temporal_onnx_model(),
+            process_id="demo_process",
+        )
+        .process
+    )
+    trace = load_golden_trace("tests/verification/golden_traces/rolling_mean.json")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_dir = Path(temp_dir)
+        manifest = write_temporal_hls_artifact_bundle(
+            process,
+            trace,
+            output_dir,
+            stem="demo",
+        )
+
+        files = {artifact.kind: artifact.path for artifact in manifest.files}
+        assert set(files) == {
+            TemporalArtifactKind.PROCESS_JSON,
+            TemporalArtifactKind.GOLDEN_TRACE_JSON,
+            TemporalArtifactKind.PROCESS_HLS,
+            TemporalArtifactKind.TESTBENCH_HLS,
+            TemporalArtifactKind.MANIFEST_JSON,
+        }
+        for path in files.values():
+            assert path.is_file()
+
+        manifest_payload = json.loads(
+            files[TemporalArtifactKind.MANIFEST_JSON].read_text()
+        )
+        assert manifest_payload["process_id"] == "demo_process"
+        assert {
+            item["kind"] for item in manifest_payload["files"]
+        } == {kind.value for kind in TemporalArtifactKind}

--- a/tests/unit/test_temporal_hls.py
+++ b/tests/unit/test_temporal_hls.py
@@ -117,6 +117,6 @@ def test_write_temporal_hls_artifact_bundle_emits_manifest_and_files() -> None:
             files[TemporalArtifactKind.MANIFEST_JSON].read_text()
         )
         assert manifest_payload["process_id"] == "demo_process"
-        assert {
-            item["kind"] for item in manifest_payload["files"]
-        } == {kind.value for kind in TemporalArtifactKind}
+        assert {item["kind"] for item in manifest_payload["files"]} == {
+            kind.value for kind in TemporalArtifactKind
+        }


### PR DESCRIPTION
﻿## Summary

This PR completes the next HLS artifact baseline by turning operator templates into compile-checked and execution-tested generated C++ artifacts.

Changes include:
- graph-level temporal HLS artifact bundle generation with manifests
- baseline HLS templates for built-in operators, including LSTM
- renderer context fields for C++ dtype, shape, broadcast, and operator-specific dimensions
- generated C++ smoke tests that compile rendered templates
- generated C++ golden-data tests that execute kernels and validate outputs
- CI support for installing `g++` before pytest so generated HLS checks run in pull requests
- documentation of the current HLS compile contract and supported subset

## Why

Previously we could prove the Python renderer emitted text, but not that generated C++ was syntactically valid or functionally correct. This adds a practical milestone-2 bar: rendered HLS kernels must compile and representative kernels must match golden outputs.

## Validation

Local checks run with portable `w64devkit`/`g++`:

- `python -m black --check .`
- `python -m ruff check .`
- `python -m pytest -q --basetemp=.pytest-tmp`

Result: `263 passed, 7 warnings`.
