### PR TITLE
Add temporal schedule ABI report

### DIFF
--- a/docs/temporal-quickstart.md
+++ b/docs/temporal-quickstart.md
@@ -36,15 +36,17 @@ The demo writes artifacts to `examples/generated/`:
 - `temporal_demo.onnx`
 - `temporal_demo_process.json`
 - `temporal_demo_trace.json`
+- `temporal_demo_schedule.json`
 - `temporal_demo.cpp`
 - `temporal_demo_tb.cpp`
 - `temporal_demo_manifest.json`
 - `temporal_demo_report.json`
 
 The manifest is the stable entry point for generated artifacts. It lists the
-temporal process JSON, golden trace, generated process HLS, and generated
-testbench for the same pipeline so downstream notebooks, reports, and future
-HLS scripts do not need to rediscover file names.
+temporal process JSON, golden trace, generated schedule report, generated
+process HLS, and generated testbench for the same pipeline so downstream
+notebooks, reports, and future HLS scripts do not need to rediscover file
+names.
 
 ## API Reference
 
@@ -74,6 +76,8 @@ The temporal HLS bundle writer produces a graph-level artifact package:
 
 - a temporal process JSON file
 - a golden trace JSON file
+- a baseline schedule JSON file with node phases, edge ABI roles, storage
+  choices, and conservative latency/II estimates
 - a top-level process wrapper with buffer declarations, contract comments, and
   rendered operator kernels
 - a testbench that replays each timestep from the golden trace
@@ -82,6 +86,22 @@ The temporal HLS bundle writer produces a graph-level artifact package:
 The generated C++ is intentionally transparent and inspection-friendly. It is
 meant to prove the process/codegen interface and testbench wiring before the
 project grows a richer temporal scheduler.
+
+## Schedule Report
+
+The schedule report is the first M3 artifact. It classifies the temporal process
+into a stable ABI that later HLS wiring can consume:
+
+- `stream` edges for same-timestep operator-to-operator values
+- `graph_input` and `graph_output` ports for runtime values
+- `parameter_block` inputs for immutable weights or constants
+- `state_read`, `buffer_read`, and temporal-delay edges for persistent state and
+  bounded history
+- per-node phase, estimated latency, and initiation interval metadata
+
+This report is deliberately conservative. It does not yet perform directive
+search or full Vitis `DATAFLOW` emission, but it gives those later passes a
+machine-readable target.
 
 ## HLS Milestone 2 Compile Contract
 
@@ -133,5 +153,5 @@ ONNX model
   -> FixedPointOracle
   -> GoldenTraceRecorder
   -> write_temporal_hls_artifact_bundle
-  -> process JSON + golden trace + HLS + testbench + manifest
+  -> process JSON + golden trace + schedule + HLS + testbench + manifest
 ```

--- a/src/tempo_dag/codegen/hls/temporal_generator.py
+++ b/src/tempo_dag/codegen/hls/temporal_generator.py
@@ -100,6 +100,10 @@ def render_temporal_process_hls(process: Process) -> str:
             f"// reset_policy: {contract.reset_policy.value}",
             f"// warmup_timesteps: {contract.warmup_timesteps}",
             f"// flush_cycles: {contract.flush_cycles}",
+            f"// schedule_estimated_latency_cycles: "
+            f"{schedule.estimated_latency_cycles}",
+            f"// schedule_estimated_initiation_interval: "
+            f"{schedule.estimated_initiation_interval}",
             *_contract_storage_comments(
                 contract.edge_delta_storage,
                 "edge_delta_storage",
@@ -126,6 +130,7 @@ def render_temporal_process_hls(process: Process) -> str:
             *[line for block in operator_blocks for line in block.splitlines()],
             "",
             f"void {process.process_id}_step() {{",
+            "#pragma HLS DATAFLOW",
             "  // Operator invocation wiring is emitted by the next scheduler layer.",
             "}",
             "",

--- a/src/tempo_dag/codegen/hls/temporal_generator.py
+++ b/src/tempo_dag/codegen/hls/temporal_generator.py
@@ -11,6 +11,7 @@ from tempo_dag.ir_temporal import (
     Process,
     TemporalStorageMapping,
     derive_temporal_execution_contract,
+    derive_temporal_schedule,
 )
 from tempo_dag.verification.golden_trace import GoldenTrace, load_golden_trace
 
@@ -22,6 +23,7 @@ class TemporalArtifactKind(Enum):
     GOLDEN_TRACE_JSON = "golden_trace_json"
     PROCESS_HLS = "process_hls"
     TESTBENCH_HLS = "testbench_hls"
+    SCHEDULE_JSON = "schedule_json"
     MANIFEST_JSON = "manifest_json"
 
 
@@ -65,6 +67,7 @@ def render_temporal_process_hls(process: Process) -> str:
     """Render a top-level HLS wrapper for a temporal process."""
 
     contract = derive_temporal_execution_contract(process)
+    schedule = derive_temporal_schedule(process)
     if len(process.kernels) != 1:
         raise ValueError("temporal HLS MVP currently supports exactly one kernel")
 
@@ -102,6 +105,18 @@ def render_temporal_process_hls(process: Process) -> str:
                 "edge_delta_storage",
             ),
             *_contract_storage_comments(contract.buffer_storage, "buffer_storage"),
+            *[
+                f"// schedule_node: {node.node_id} kind={node.kind.value} "
+                f"phase={node.phase} latency={node.latency_cycles} "
+                f"ii={node.initiation_interval}"
+                for node in schedule.nodes
+            ],
+            *[
+                f"// schedule_edge: {edge.edge_id} kind={edge.kind.value} "
+                f"phase={edge.phase} storage="
+                f"{edge.storage_kind.value if edge.storage_kind else 'none'}"
+                for edge in schedule.edges
+            ],
             *header_blocks,
             "",
             *buffer_blocks,
@@ -208,6 +223,7 @@ def write_temporal_hls_artifact_bundle(
 
     process_path = output_path / f"{artifact_stem}_process.json"
     trace_path = output_path / f"{artifact_stem}_trace.json"
+    schedule_path = output_path / f"{artifact_stem}_schedule.json"
     hls_path = output_path / f"{artifact_stem}.cpp"
     testbench_path = output_path / f"{artifact_stem}_tb.cpp"
     manifest_path = output_path / f"{artifact_stem}_manifest.json"
@@ -220,6 +236,15 @@ def write_temporal_hls_artifact_bundle(
         json.dumps(golden_trace.to_dict(), indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+    schedule_path.write_text(
+        json.dumps(
+            derive_temporal_schedule(process).to_dict(),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     hls_path.write_text(rendered.process_hls, encoding="utf-8")
     testbench_path.write_text(rendered.testbench_hls, encoding="utf-8")
 
@@ -228,6 +253,7 @@ def write_temporal_hls_artifact_bundle(
         files=(
             TemporalArtifactFile(TemporalArtifactKind.PROCESS_JSON, process_path),
             TemporalArtifactFile(TemporalArtifactKind.GOLDEN_TRACE_JSON, trace_path),
+            TemporalArtifactFile(TemporalArtifactKind.SCHEDULE_JSON, schedule_path),
             TemporalArtifactFile(TemporalArtifactKind.PROCESS_HLS, hls_path),
             TemporalArtifactFile(TemporalArtifactKind.TESTBENCH_HLS, testbench_path),
             TemporalArtifactFile(TemporalArtifactKind.MANIFEST_JSON, manifest_path),

--- a/src/tempo_dag/codegen/hls/temporal_generator.py
+++ b/src/tempo_dag/codegen/hls/temporal_generator.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from tempo_dag.codegen.hls.generator import render_operator_hls
 from tempo_dag.ir_temporal import (
     Process,
+    TemporalExecutionContract,
+    TemporalSchedule,
     TemporalStorageMapping,
     derive_temporal_execution_contract,
     derive_temporal_schedule,
@@ -63,11 +65,18 @@ class TemporalHLSArtifactManifest:
         }
 
 
-def render_temporal_process_hls(process: Process) -> str:
+def render_temporal_process_hls(
+    process: Process,
+    *,
+    contract: TemporalExecutionContract | None = None,
+    schedule: TemporalSchedule | None = None,
+) -> str:
     """Render a top-level HLS wrapper for a temporal process."""
 
-    contract = derive_temporal_execution_contract(process)
-    schedule = derive_temporal_schedule(process)
+    if contract is None:
+        contract = derive_temporal_execution_contract(process)
+    if schedule is None:
+        schedule = derive_temporal_schedule(process, contract)
     if len(process.kernels) != 1:
         raise ValueError("temporal HLS MVP currently supports exactly one kernel")
 
@@ -205,9 +214,16 @@ def _to_cpp_dtype(dtype: str) -> str:
 def render_temporal_artifact_from_trace(
     process: Process,
     golden_trace: GoldenTrace,
+    *,
+    contract: TemporalExecutionContract | None = None,
+    schedule: TemporalSchedule | None = None,
 ) -> TemporalHLSArtifact:
     return TemporalHLSArtifact(
-        process_hls=render_temporal_process_hls(process),
+        process_hls=render_temporal_process_hls(
+            process,
+            contract=contract,
+            schedule=schedule,
+        ),
         testbench_hls=render_temporal_testbench(process, golden_trace),
     )
 
@@ -224,7 +240,14 @@ def write_temporal_hls_artifact_bundle(
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
     artifact_stem = stem or process.process_id
-    rendered = render_temporal_artifact_from_trace(process, golden_trace)
+    contract = derive_temporal_execution_contract(process)
+    schedule = derive_temporal_schedule(process, contract)
+    rendered = render_temporal_artifact_from_trace(
+        process,
+        golden_trace,
+        contract=contract,
+        schedule=schedule,
+    )
 
     process_path = output_path / f"{artifact_stem}_process.json"
     trace_path = output_path / f"{artifact_stem}_trace.json"
@@ -243,7 +266,7 @@ def write_temporal_hls_artifact_bundle(
     )
     schedule_path.write_text(
         json.dumps(
-            derive_temporal_schedule(process).to_dict(),
+            schedule.to_dict(),
             indent=2,
             sort_keys=True,
         )

--- a/src/tempo_dag/ir_temporal/__init__.py
+++ b/src/tempo_dag/ir_temporal/__init__.py
@@ -17,6 +17,14 @@ from .process import (
     TemporalIRValidationError,
     validate_temporal_process,
 )
+from .schedule import (
+    ScheduleEdge,
+    ScheduleEdgeKind,
+    ScheduleNode,
+    ScheduleNodeKind,
+    TemporalSchedule,
+    derive_temporal_schedule,
+)
 
 __all__ = [
     "BufferSpec",
@@ -26,12 +34,18 @@ __all__ = [
     "Kernel",
     "Process",
     "ResetPolicy",
+    "ScheduleEdge",
+    "ScheduleEdgeKind",
+    "ScheduleNode",
+    "ScheduleNodeKind",
     "StateKind",
     "StateSpec",
     "TemporalExecutionContract",
     "TemporalIRValidationError",
+    "TemporalSchedule",
     "TemporalStorageKind",
     "TemporalStorageMapping",
     "derive_temporal_execution_contract",
+    "derive_temporal_schedule",
     "validate_temporal_process",
 ]

--- a/src/tempo_dag/ir_temporal/schedule.py
+++ b/src/tempo_dag/ir_temporal/schedule.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from enum import Enum
+
+from tempo_dag.ir.op import FPGACost
+from tempo_dag.ir_temporal.contract import (
+    TemporalStorageKind,
+    derive_temporal_execution_contract,
+)
+from tempo_dag.ir_temporal.process import Edge0, EdgeDelta, Kernel, Process
+
+
+class ScheduleNodeKind(Enum):
+    """Component categories visible to the process-level scheduler."""
+
+    KERNEL = "kernel"
+    OPERATOR = "operator"
+    STATE = "state"
+    BUFFER = "buffer"
+
+
+class ScheduleEdgeKind(Enum):
+    """ABI role assigned to one data/control dependency."""
+
+    STREAM = "stream"
+    GRAPH_INPUT = "graph_input"
+    GRAPH_OUTPUT = "graph_output"
+    PARAMETER_BLOCK = "parameter_block"
+    STATE_READ = "state_read"
+    STATE_WRITE = "state_write"
+    BUFFER_READ = "buffer_read"
+    BUFFER_WRITE = "buffer_write"
+    TEMPORAL_DELAY = "temporal_delay"
+
+
+@dataclass(frozen=True)
+class ScheduleNode:
+    """One scheduled component or operator."""
+
+    node_id: str
+    kind: ScheduleNodeKind
+    phase: int
+    latency_cycles: int = 0
+    initiation_interval: int = 1
+    metadata: dict[str, object] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "node_id": self.node_id,
+            "kind": self.kind.value,
+            "phase": self.phase,
+            "latency_cycles": self.latency_cycles,
+            "initiation_interval": self.initiation_interval,
+            "metadata": dict(self.metadata or {}),
+        }
+
+
+@dataclass(frozen=True)
+class ScheduleEdge:
+    """One scheduled ABI edge between components, ops, or external ports."""
+
+    edge_id: str
+    kind: ScheduleEdgeKind
+    source: str
+    target: str
+    value_id: str | None = None
+    storage_kind: TemporalStorageKind | None = None
+    latency_cycles: int = 0
+    phase: int = 0
+    metadata: dict[str, object] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "edge_id": self.edge_id,
+            "kind": self.kind.value,
+            "source": self.source,
+            "target": self.target,
+            "value_id": self.value_id,
+            "latency_cycles": self.latency_cycles,
+            "phase": self.phase,
+            "metadata": dict(self.metadata or {}),
+        }
+        if self.storage_kind is not None:
+            payload["storage_kind"] = self.storage_kind.value
+        return payload
+
+
+@dataclass(frozen=True)
+class TemporalSchedule:
+    """Baseline task-level schedule and ABI classification for a process."""
+
+    process_id: str
+    nodes: tuple[ScheduleNode, ...]
+    edges: tuple[ScheduleEdge, ...]
+    estimated_latency_cycles: int
+    estimated_initiation_interval: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "process_id": self.process_id,
+            "estimated_latency_cycles": self.estimated_latency_cycles,
+            "estimated_initiation_interval": self.estimated_initiation_interval,
+            "nodes": [node.to_dict() for node in self.nodes],
+            "edges": [edge.to_dict() for edge in self.edges],
+        }
+
+
+def derive_temporal_schedule(process: Process) -> TemporalSchedule:
+    """Derive a conservative task-level schedule and channel ABI report."""
+
+    process.validate()
+    contract = derive_temporal_execution_contract(process)
+    component_phases = _component_phases(process)
+    nodes: list[ScheduleNode] = []
+    edges: list[ScheduleEdge] = []
+
+    for state_id in sorted(process.states):
+        nodes.append(
+            ScheduleNode(
+                node_id=state_id,
+                kind=ScheduleNodeKind.STATE,
+                phase=component_phases.get(state_id, 0),
+            )
+        )
+    for buffer_id, buffer in sorted(process.buffers.items()):
+        nodes.append(
+            ScheduleNode(
+                node_id=buffer_id,
+                kind=ScheduleNodeKind.BUFFER,
+                phase=component_phases.get(buffer_id, 0),
+                latency_cycles=buffer.depth,
+                metadata={"depth": buffer.depth},
+            )
+        )
+    for kernel_id, kernel in sorted(process.kernels.items()):
+        kernel_cost = _kernel_cost(kernel)
+        nodes.append(
+            ScheduleNode(
+                node_id=kernel_id,
+                kind=ScheduleNodeKind.KERNEL,
+                phase=component_phases.get(kernel_id, 0),
+                latency_cycles=kernel_cost.latency_cycles,
+                initiation_interval=kernel_cost.initiation_interval,
+                metadata={"clock_id": kernel.clock_id},
+            )
+        )
+        operator_nodes, operator_edges = _kernel_schedule(
+            kernel,
+            component_phases[kernel_id],
+        )
+        nodes.extend(operator_nodes)
+        edges.extend(operator_edges)
+
+    buffer_storage = {
+        mapping.component_id: mapping.storage_kind
+        for mapping in contract.buffer_storage
+    }
+    temporal_storage = {
+        mapping.component_id: mapping.storage_kind
+        for mapping in contract.edge_delta_storage
+    }
+    for edge in process.edge0:
+        edges.append(
+            _schedule_edge0(
+                process,
+                edge,
+                phase=component_phases.get(edge.target, 0),
+                buffer_storage=buffer_storage,
+            )
+        )
+    for edge in process.edge_delta:
+        edge_id = _edge_delta_id(edge)
+        edges.append(
+            ScheduleEdge(
+                edge_id=edge_id,
+                kind=ScheduleEdgeKind.TEMPORAL_DELAY,
+                source=edge.source,
+                target=edge.target,
+                value_id=edge.value_id,
+                storage_kind=temporal_storage.get(edge_id),
+                latency_cycles=edge.lag_cycles,
+                phase=component_phases.get(edge.target, 0),
+                metadata={"lag_cycles": edge.lag_cycles},
+            )
+        )
+
+    estimated_latency = sum(
+        node.latency_cycles for node in nodes if node.kind is ScheduleNodeKind.KERNEL
+    )
+    estimated_latency += max((edge.latency_cycles for edge in edges), default=0)
+    estimated_ii = max((node.initiation_interval for node in nodes), default=1)
+    return TemporalSchedule(
+        process_id=process.process_id,
+        nodes=tuple(sorted(nodes, key=lambda node: (node.phase, node.node_id))),
+        edges=tuple(sorted(edges, key=lambda edge: (edge.phase, edge.edge_id))),
+        estimated_latency_cycles=max(1, estimated_latency),
+        estimated_initiation_interval=max(1, estimated_ii),
+    )
+
+
+def _component_phases(process: Process) -> dict[str, int]:
+    component_ids = process.component_ids()
+    adjacency: dict[str, list[str]] = defaultdict(list)
+    indegree = {component_id: 0 for component_id in component_ids}
+    for edge in process.edge0:
+        adjacency[edge.source].append(edge.target)
+        indegree[edge.target] += 1
+
+    ready = deque(sorted(node for node, degree in indegree.items() if degree == 0))
+    phases = {node: 0 for node in ready}
+    while ready:
+        node = ready.popleft()
+        for target in sorted(adjacency[node]):
+            phases[target] = max(phases.get(target, 0), phases[node] + 1)
+            indegree[target] -= 1
+            if indegree[target] == 0:
+                ready.append(target)
+    return phases
+
+
+def _kernel_schedule(
+    kernel: Kernel,
+    kernel_phase: int,
+) -> tuple[list[ScheduleNode], list[ScheduleEdge]]:
+    graph = kernel.graph
+    op_phases = _operator_phases(kernel)
+    value_producers = _value_producers(kernel)
+    nodes: list[ScheduleNode] = []
+    edges: list[ScheduleEdge] = []
+
+    for op_id, operator in sorted(graph.ops.items()):
+        cost = operator.estimate_fpga_cost(graph.values)
+        phase = kernel_phase + op_phases[op_id]
+        nodes.append(
+            ScheduleNode(
+                node_id=f"{kernel.kernel_id}.{op_id}",
+                kind=ScheduleNodeKind.OPERATOR,
+                phase=phase,
+                latency_cycles=cost.latency_cycles,
+                initiation_interval=cost.initiation_interval,
+                metadata={
+                    "kernel_id": kernel.kernel_id,
+                    "op_type": operator.op_type,
+                    "dsp": cost.dsp,
+                    "bram": cost.bram,
+                    "lut": cost.lut,
+                    "ff": cost.ff,
+                },
+            )
+        )
+        for input_id in operator.inputs:
+            producer = value_producers.get(input_id)
+            if producer is not None:
+                edges.append(
+                    ScheduleEdge(
+                        edge_id=f"{kernel.kernel_id}.{producer}->{op_id}:{input_id}",
+                        kind=ScheduleEdgeKind.STREAM,
+                        source=f"{kernel.kernel_id}.{producer}",
+                        target=f"{kernel.kernel_id}.{op_id}",
+                        value_id=input_id,
+                        storage_kind=TemporalStorageKind.WIRE,
+                        phase=phase,
+                    )
+                )
+            elif input_id in graph.graph_inputs:
+                value = graph.values[input_id]
+                if _is_parameter_value(value):
+                    edges.append(
+                        ScheduleEdge(
+                            edge_id=f"{kernel.kernel_id}.param->{op_id}:{input_id}",
+                            kind=ScheduleEdgeKind.PARAMETER_BLOCK,
+                            source=f"{kernel.kernel_id}.parameter",
+                            target=f"{kernel.kernel_id}.{op_id}",
+                            value_id=input_id,
+                            storage_kind=TemporalStorageKind.RAM,
+                            phase=phase,
+                        )
+                    )
+                else:
+                    edges.append(
+                        ScheduleEdge(
+                            edge_id=f"{kernel.kernel_id}.input->{op_id}:{input_id}",
+                            kind=ScheduleEdgeKind.GRAPH_INPUT,
+                            source=f"{kernel.kernel_id}.input",
+                            target=f"{kernel.kernel_id}.{op_id}",
+                            value_id=input_id,
+                            phase=phase,
+                        )
+                    )
+            else:
+                edges.append(
+                    ScheduleEdge(
+                        edge_id=f"{kernel.kernel_id}.param->{op_id}:{input_id}",
+                        kind=ScheduleEdgeKind.PARAMETER_BLOCK,
+                        source=f"{kernel.kernel_id}.parameter",
+                        target=f"{kernel.kernel_id}.{op_id}",
+                        value_id=input_id,
+                        storage_kind=TemporalStorageKind.RAM,
+                        phase=phase,
+                    )
+                )
+
+    for output_id in graph.graph_outputs:
+        producer = value_producers.get(output_id)
+        if producer is not None:
+            edges.append(
+                ScheduleEdge(
+                    edge_id=f"{kernel.kernel_id}.{producer}->output:{output_id}",
+                    kind=ScheduleEdgeKind.GRAPH_OUTPUT,
+                    source=f"{kernel.kernel_id}.{producer}",
+                    target=f"{kernel.kernel_id}.output",
+                    value_id=output_id,
+                    phase=kernel_phase + op_phases[producer],
+                )
+            )
+    return nodes, edges
+
+
+def _operator_phases(kernel: Kernel) -> dict[str, int]:
+    graph = kernel.graph
+    value_producers = _value_producers(kernel)
+    adjacency: dict[str, list[str]] = defaultdict(list)
+    indegree = {op_id: 0 for op_id in graph.ops}
+    for op_id, operator in graph.ops.items():
+        for input_id in operator.inputs:
+            producer = value_producers.get(input_id)
+            if producer is not None and producer != op_id:
+                adjacency[producer].append(op_id)
+                indegree[op_id] += 1
+
+    ready = deque(sorted(op_id for op_id, degree in indegree.items() if degree == 0))
+    phases = {op_id: 0 for op_id in ready}
+    while ready:
+        op_id = ready.popleft()
+        for target in sorted(adjacency[op_id]):
+            phases[target] = max(phases.get(target, 0), phases[op_id] + 1)
+            indegree[target] -= 1
+            if indegree[target] == 0:
+                ready.append(target)
+    return phases
+
+
+def _value_producers(kernel: Kernel) -> dict[str, str]:
+    producers = {}
+    for op_id, operator in kernel.graph.ops.items():
+        for output_id in operator.outputs:
+            producers[output_id] = op_id
+    return producers
+
+
+def _is_parameter_value(value: object) -> bool:
+    layout = getattr(value, "layout", None)
+    quant = getattr(value, "quant", None)
+    return layout == "parameter" or (
+        isinstance(quant, dict) and quant.get("role") == "parameter"
+    )
+
+
+def _kernel_cost(kernel: Kernel) -> FPGACost:
+    costs = [
+        operator.estimate_fpga_cost(kernel.graph.values)
+        for operator in kernel.graph.ops.values()
+    ]
+    if not costs:
+        return FPGACost(latency_cycles=1)
+    return FPGACost(
+        latency_cycles=sum(cost.latency_cycles for cost in costs),
+        initiation_interval=max(cost.initiation_interval for cost in costs),
+        dsp=sum(cost.dsp for cost in costs),
+        bram=sum(cost.bram for cost in costs),
+        lut=sum(cost.lut for cost in costs),
+        ff=sum(cost.ff for cost in costs),
+    )
+
+
+def _schedule_edge0(
+    process: Process,
+    edge: Edge0,
+    *,
+    phase: int,
+    buffer_storage: dict[str, TemporalStorageKind],
+) -> ScheduleEdge:
+    kind = ScheduleEdgeKind.STREAM
+    storage_kind = TemporalStorageKind.WIRE
+    if edge.source in process.states and edge.target in process.kernels:
+        kind = ScheduleEdgeKind.STATE_READ
+        storage_kind = TemporalStorageKind.REGISTER
+    elif edge.source in process.kernels and edge.target in process.states:
+        kind = ScheduleEdgeKind.STATE_WRITE
+        storage_kind = TemporalStorageKind.REGISTER
+    elif edge.source in process.buffers and edge.target in process.kernels:
+        kind = ScheduleEdgeKind.BUFFER_READ
+        storage_kind = buffer_storage.get(edge.source, TemporalStorageKind.RING_BUFFER)
+    elif edge.source in process.kernels and edge.target in process.buffers:
+        kind = ScheduleEdgeKind.BUFFER_WRITE
+        storage_kind = buffer_storage.get(edge.target, TemporalStorageKind.RING_BUFFER)
+    return ScheduleEdge(
+        edge_id=f"{edge.source}->{edge.target}:{edge.value_id or 'value'}",
+        kind=kind,
+        source=edge.source,
+        target=edge.target,
+        value_id=edge.value_id,
+        storage_kind=storage_kind,
+        phase=phase,
+    )
+
+
+def _edge_delta_id(edge: EdgeDelta) -> str:
+    value_suffix = f":{edge.value_id}" if edge.value_id else ""
+    return f"{edge.source}->{edge.target}@{edge.lag_cycles}{value_suffix}"

--- a/src/tempo_dag/ir_temporal/schedule.py
+++ b/src/tempo_dag/ir_temporal/schedule.py
@@ -116,6 +116,10 @@ def derive_temporal_schedule(
 
     if contract is None:
         contract = derive_temporal_execution_contract(process)
+    elif contract.process_id != process.process_id:
+        raise ValueError(
+            "temporal execution contract process_id does not match process_id"
+        )
     component_phases = _component_phases(process)
     nodes: list[ScheduleNode] = []
     edges: list[ScheduleEdge] = []

--- a/src/tempo_dag/ir_temporal/schedule.py
+++ b/src/tempo_dag/ir_temporal/schedule.py
@@ -6,6 +6,7 @@ from enum import Enum
 
 from tempo_dag.ir.op import FPGACost
 from tempo_dag.ir_temporal.contract import (
+    TemporalExecutionContract,
     TemporalStorageKind,
     derive_temporal_execution_contract,
 )
@@ -107,11 +108,14 @@ class TemporalSchedule:
         }
 
 
-def derive_temporal_schedule(process: Process) -> TemporalSchedule:
+def derive_temporal_schedule(
+    process: Process,
+    contract: TemporalExecutionContract | None = None,
+) -> TemporalSchedule:
     """Derive a conservative task-level schedule and channel ABI report."""
 
-    process.validate()
-    contract = derive_temporal_execution_contract(process)
+    if contract is None:
+        contract = derive_temporal_execution_contract(process)
     component_phases = _component_phases(process)
     nodes: list[ScheduleNode] = []
     edges: list[ScheduleEdge] = []
@@ -271,7 +275,7 @@ def _kernel_schedule(
                         ScheduleEdge(
                             edge_id=f"{kernel.kernel_id}.param->{op_id}:{input_id}",
                             kind=ScheduleEdgeKind.PARAMETER_BLOCK,
-                            source=f"{kernel.kernel_id}.parameter",
+                            source=f"{kernel.kernel_id}.param",
                             target=f"{kernel.kernel_id}.{op_id}",
                             value_id=input_id,
                             storage_kind=TemporalStorageKind.RAM,
@@ -294,7 +298,7 @@ def _kernel_schedule(
                     ScheduleEdge(
                         edge_id=f"{kernel.kernel_id}.param->{op_id}:{input_id}",
                         kind=ScheduleEdgeKind.PARAMETER_BLOCK,
-                        source=f"{kernel.kernel_id}.parameter",
+                        source=f"{kernel.kernel_id}.param",
                         target=f"{kernel.kernel_id}.{op_id}",
                         value_id=input_id,
                         storage_kind=TemporalStorageKind.RAM,

--- a/tests/integration/test_temporal_demo_pipeline.py
+++ b/tests/integration/test_temporal_demo_pipeline.py
@@ -19,6 +19,7 @@ def test_temporal_demo_pipeline_emits_artifacts() -> None:
     assert (output_dir / "temporal_demo_tb.cpp").is_file()
     assert (output_dir / "temporal_demo_trace.json").is_file()
     assert (output_dir / "temporal_demo_process.json").is_file()
+    assert (output_dir / "temporal_demo_schedule.json").is_file()
     assert (output_dir / "temporal_demo_manifest.json").is_file()
     assert report.manifest_path == str(output_dir / "temporal_demo_manifest.json")
 

--- a/tests/unit/test_hls_cpp_smoke.py
+++ b/tests/unit/test_hls_cpp_smoke.py
@@ -192,7 +192,11 @@ def test_temporal_process_hls_emits_operator_kernels_at_file_scope() -> None:
     assert (
         "template <typename T, int Window>\nvoid rolling_mean_node_kernel" in rendered
     )
-    assert "void demo_process_step() {\n  // Operator invocation wiring" in rendered
+    assert "void demo_process_step() {" in rendered
+    assert "#pragma HLS DATAFLOW" in rendered
+    assert (
+        "Operator invocation wiring is emitted by the next scheduler layer" in rendered
+    )
 
 
 def _render_binary(operator: Operator) -> str:

--- a/tests/unit/test_temporal_hls.py
+++ b/tests/unit/test_temporal_hls.py
@@ -77,6 +77,8 @@ def test_render_temporal_process_hls_includes_execution_contract_comments() -> N
     assert "// reset_policy: zero" in rendered
     assert "// warmup_timesteps: 7" in rendered
     assert "// flush_cycles: 0" in rendered
+    assert "// schedule_estimated_latency_cycles:" in rendered
+    assert "// schedule_estimated_initiation_interval: 1" in rendered
     assert "// edge_delta_storage: feature_kernel->rolling_window@1:x" in rendered
     assert "-> register latency=1" in rendered
     assert "// buffer_storage: rolling_window -> ring_buffer latency=8" in rendered
@@ -85,6 +87,7 @@ def test_render_temporal_process_hls_includes_execution_contract_comments() -> N
     assert (
         "// schedule_edge: feature_kernel->rolling_window@1:x " "kind=temporal_delay"
     ) in rendered
+    assert "#pragma HLS DATAFLOW" in rendered
 
 
 def test_write_temporal_hls_artifact_bundle_emits_manifest_and_files() -> None:

--- a/tests/unit/test_temporal_hls.py
+++ b/tests/unit/test_temporal_hls.py
@@ -80,6 +80,11 @@ def test_render_temporal_process_hls_includes_execution_contract_comments() -> N
     assert "// edge_delta_storage: feature_kernel->rolling_window@1:x" in rendered
     assert "-> register latency=1" in rendered
     assert "// buffer_storage: rolling_window -> ring_buffer latency=8" in rendered
+    assert "// schedule_node: feature_kernel kind=kernel phase=1" in rendered
+    assert "// schedule_node: rolling_window kind=buffer phase=0" in rendered
+    assert (
+        "// schedule_edge: feature_kernel->rolling_window@1:x " "kind=temporal_delay"
+    ) in rendered
 
 
 def test_write_temporal_hls_artifact_bundle_emits_manifest_and_files() -> None:
@@ -106,6 +111,7 @@ def test_write_temporal_hls_artifact_bundle_emits_manifest_and_files() -> None:
         assert set(files) == {
             TemporalArtifactKind.PROCESS_JSON,
             TemporalArtifactKind.GOLDEN_TRACE_JSON,
+            TemporalArtifactKind.SCHEDULE_JSON,
             TemporalArtifactKind.PROCESS_HLS,
             TemporalArtifactKind.TESTBENCH_HLS,
             TemporalArtifactKind.MANIFEST_JSON,
@@ -116,7 +122,13 @@ def test_write_temporal_hls_artifact_bundle_emits_manifest_and_files() -> None:
         manifest_payload = json.loads(
             files[TemporalArtifactKind.MANIFEST_JSON].read_text()
         )
+        schedule_payload = json.loads(
+            files[TemporalArtifactKind.SCHEDULE_JSON].read_text()
+        )
         assert manifest_payload["process_id"] == "demo_process"
+        assert schedule_payload["process_id"] == "demo_process"
+        assert schedule_payload["nodes"]
+        assert schedule_payload["edges"]
         assert {item["kind"] for item in manifest_payload["files"]} == {
             kind.value for kind in TemporalArtifactKind
         }

--- a/tests/unit/test_temporal_schedule.py
+++ b/tests/unit/test_temporal_schedule.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from tempo_dag.ir.graph import Graph
 from tempo_dag.ir.value import Value, ValueType
 from tempo_dag.ir_temporal import (
@@ -156,8 +158,9 @@ def test_schedule_serializes_to_report_dict() -> None:
     )
 
     payload = derive_temporal_schedule(process).to_dict()
+    nodes = cast(list[dict[str, object]], payload["nodes"])
 
     assert payload["process_id"] == "empty_kernel"
     assert payload["estimated_latency_cycles"] == 1
     assert payload["estimated_initiation_interval"] == 1
-    assert payload["nodes"][0]["node_id"] == "kernel"
+    assert nodes[0]["node_id"] == "kernel"

--- a/tests/unit/test_temporal_schedule.py
+++ b/tests/unit/test_temporal_schedule.py
@@ -93,6 +93,7 @@ def test_schedule_classifies_parameters_and_operator_cost_metadata() -> None:
     matmul = next(node for node in schedule.nodes if node.node_id == "kernel.matmul")
 
     assert edges["kernel.param->matmul:w"].kind == ScheduleEdgeKind.PARAMETER_BLOCK
+    assert edges["kernel.param->matmul:w"].source == "kernel.param"
     assert edges["kernel.param->matmul:w"].storage_kind == TemporalStorageKind.RAM
     assert matmul.metadata == {
         "kernel_id": "kernel",

--- a/tests/unit/test_temporal_schedule.py
+++ b/tests/unit/test_temporal_schedule.py
@@ -1,0 +1,163 @@
+from tempo_dag.ir.graph import Graph
+from tempo_dag.ir.value import Value, ValueType
+from tempo_dag.ir_temporal import (
+    BufferSpec,
+    Edge0,
+    EdgeDelta,
+    Kernel,
+    Process,
+    ScheduleEdgeKind,
+    ScheduleNodeKind,
+    StateKind,
+    StateSpec,
+    TemporalStorageKind,
+    derive_temporal_schedule,
+)
+from tempo_dag.ops.builtins import Add, MatMul, Mul
+
+
+def tensor(
+    value_id: str,
+    shape: list[int],
+    *,
+    layout: str | None = None,
+    quant: dict[str, float | int | str | None] | None = None,
+) -> Value:
+    return Value(
+        value_id=value_id,
+        vtype=ValueType.TENSOR,
+        dtype="float32",
+        shape=shape,
+        axes=[f"axis_{idx}" for idx in range(len(shape))],
+        layout=layout,
+        quant=quant,
+    )
+
+
+def test_schedule_classifies_operator_streams_and_graph_ports() -> None:
+    values = {
+        "x": tensor("x", [2]),
+        "y": tensor("y", [2]),
+        "z": tensor("z", [2]),
+        "out": tensor("out", [2]),
+    }
+    graph = Graph(
+        values=values,
+        ops={
+            "add": Add("add", inputs=["x", "y"], outputs=["z"]),
+            "mul": Mul("mul", inputs=["z", "y"], outputs=["out"]),
+        },
+        graph_inputs=["x", "y"],
+        graph_outputs=["out"],
+    )
+    process = Process(
+        process_id="stateless_chain",
+        kernels={"main_kernel": Kernel("main_kernel", graph=graph)},
+    )
+
+    schedule = derive_temporal_schedule(process)
+    edges = {edge.edge_id: edge for edge in schedule.edges}
+    nodes = {node.node_id: node for node in schedule.nodes}
+
+    assert nodes["main_kernel"].kind == ScheduleNodeKind.KERNEL
+    assert nodes["main_kernel.add"].phase == 0
+    assert nodes["main_kernel.mul"].phase == 1
+    assert edges["main_kernel.input->add:x"].kind == ScheduleEdgeKind.GRAPH_INPUT
+    assert edges["main_kernel.add->mul:z"].kind == ScheduleEdgeKind.STREAM
+    assert edges["main_kernel.mul->output:out"].kind == ScheduleEdgeKind.GRAPH_OUTPUT
+    assert schedule.estimated_initiation_interval == 1
+    assert schedule.estimated_latency_cycles >= 1
+
+
+def test_schedule_classifies_parameters_and_operator_cost_metadata() -> None:
+    values = {
+        "x": tensor("x", [2, 3]),
+        "w": tensor("w", [3, 4], layout="parameter"),
+        "out": tensor("out", [2, 4]),
+    }
+    graph = Graph(
+        values=values,
+        ops={"matmul": MatMul("matmul", inputs=["x", "w"], outputs=["out"])},
+        graph_inputs=["x", "w"],
+        graph_outputs=["out"],
+    )
+    process = Process(
+        process_id="parameterized_kernel",
+        kernels={"kernel": Kernel("kernel", graph=graph)},
+    )
+
+    schedule = derive_temporal_schedule(process)
+    edges = {edge.edge_id: edge for edge in schedule.edges}
+    matmul = next(node for node in schedule.nodes if node.node_id == "kernel.matmul")
+
+    assert edges["kernel.param->matmul:w"].kind == ScheduleEdgeKind.PARAMETER_BLOCK
+    assert edges["kernel.param->matmul:w"].storage_kind == TemporalStorageKind.RAM
+    assert matmul.metadata == {
+        "kernel_id": "kernel",
+        "op_type": "MatMul",
+        "dsp": 3,
+        "bram": 0,
+        "lut": 8,
+        "ff": 8,
+    }
+
+
+def test_schedule_classifies_state_buffer_and_temporal_delay_edges() -> None:
+    graph = Graph(values={}, ops={}, graph_inputs=[], graph_outputs=[])
+    process = Process(
+        process_id="rolling_state",
+        kernels={"kernel": Kernel("kernel", graph=graph)},
+        states={
+            "hidden": StateSpec(
+                state_id="hidden",
+                kind=StateKind.HIDDEN,
+                dtype="float32",
+                shape=(4,),
+            )
+        },
+        buffers={
+            "window": BufferSpec(
+                buffer_id="window",
+                dtype="float32",
+                shape=(1,),
+                depth=8,
+            )
+        },
+        edge0=[
+            Edge0("hidden", "kernel", value_id="h_prev"),
+            Edge0("window", "kernel", value_id="window_view"),
+        ],
+        edge_delta=[
+            EdgeDelta("kernel", "hidden", lag_cycles=1, value_id="h_next"),
+            EdgeDelta("kernel", "window", lag_cycles=8, value_id="x_t"),
+        ],
+    )
+
+    schedule = derive_temporal_schedule(process)
+    edge_kinds = {edge.edge_id: edge.kind for edge in schedule.edges}
+    storage = {edge.edge_id: edge.storage_kind for edge in schedule.edges}
+
+    assert edge_kinds["hidden->kernel:h_prev"] == ScheduleEdgeKind.STATE_READ
+    assert edge_kinds["window->kernel:window_view"] == ScheduleEdgeKind.BUFFER_READ
+    assert edge_kinds["kernel->hidden@1:h_next"] == ScheduleEdgeKind.TEMPORAL_DELAY
+    assert storage["window->kernel:window_view"] == TemporalStorageKind.RING_BUFFER
+    assert storage["kernel->window@8:x_t"] == TemporalStorageKind.SHIFT_REGISTER
+
+
+def test_schedule_serializes_to_report_dict() -> None:
+    process = Process(
+        process_id="empty_kernel",
+        kernels={
+            "kernel": Kernel(
+                "kernel",
+                graph=Graph(values={}, ops={}, graph_inputs=[], graph_outputs=[]),
+            )
+        },
+    )
+
+    payload = derive_temporal_schedule(process).to_dict()
+
+    assert payload["process_id"] == "empty_kernel"
+    assert payload["estimated_latency_cycles"] == 1
+    assert payload["estimated_initiation_interval"] == 1
+    assert payload["nodes"][0]["node_id"] == "kernel"

--- a/tests/unit/test_temporal_schedule.py
+++ b/tests/unit/test_temporal_schedule.py
@@ -1,5 +1,7 @@
 from typing import cast
 
+import pytest
+
 from tempo_dag.ir.graph import Graph
 from tempo_dag.ir.value import Value, ValueType
 from tempo_dag.ir_temporal import (
@@ -8,10 +10,12 @@ from tempo_dag.ir_temporal import (
     EdgeDelta,
     Kernel,
     Process,
+    ResetPolicy,
     ScheduleEdgeKind,
     ScheduleNodeKind,
     StateKind,
     StateSpec,
+    TemporalExecutionContract,
     TemporalStorageKind,
     derive_temporal_schedule,
 )
@@ -165,3 +169,26 @@ def test_schedule_serializes_to_report_dict() -> None:
     assert payload["estimated_latency_cycles"] == 1
     assert payload["estimated_initiation_interval"] == 1
     assert nodes[0]["node_id"] == "kernel"
+
+
+def test_schedule_rejects_contract_for_different_process() -> None:
+    process = Process(
+        process_id="actual_process",
+        kernels={
+            "kernel": Kernel(
+                "kernel",
+                graph=Graph(values={}, ops={}, graph_inputs=[], graph_outputs=[]),
+            )
+        },
+    )
+    contract = TemporalExecutionContract(
+        process_id="other_process",
+        reset_policy=ResetPolicy.ZERO,
+        warmup_timesteps=0,
+        flush_cycles=0,
+        edge_delta_storage=(),
+        buffer_storage=(),
+    )
+
+    with pytest.raises(ValueError, match="process_id"):
+        derive_temporal_schedule(process, contract)


### PR DESCRIPTION
﻿## Summary

This PR starts M3 by adding the first task-level streaming scheduler/channel ABI layer for temporal processes.

Changes include:
- `derive_temporal_schedule(process)` for a conservative schedule and ABI report
- schedule node classification for kernels, operators, states, and buffers
- schedule edge classification for streams, graph inputs/outputs, parameter blocks, state/buffer reads, and temporal delays
- latency/II estimates based on existing operator cost models
- `*_schedule.json` emitted in HLS artifact bundles
- schedule comments and a `#pragma HLS DATAFLOW` anchor in generated temporal HLS wrappers
- docs and tests covering stateless chains, parameter blocks, rolling buffers, temporal delays, and artifact bundle schedule output

## Why

M2 gave us compile-checked and golden-data-tested generated HLS kernels. M3 needs a scheduler/channel ABI so those kernels can become a real temporal accelerator structure. This PR creates the machine-readable schedule contract that future top-level HLS wiring, stream channels, persistent state handling, and directive optimization can consume.

## Validation

Local checks run with portable `w64devkit`/`g++`:

- `python -m black --check .`
- `python -m ruff check .`
- `python -m pytest -q --basetemp=.pytest-tmp`

Result: `270 passed, 7 warnings`.

## Milestone completeness note

This is the first M3 foundation slice, not all of M3. Remaining M3 work includes real operator invocation wiring, stream/channel codegen, state/buffer update codegen, and richer schedule/cost reports.
